### PR TITLE
Add default attribute support in the OCaml backend

### DIFF
--- a/src/integration-tests/test01.proto
+++ b/src/integration-tests/test01.proto
@@ -10,9 +10,9 @@ message Person {
         required int32 area_code = 1;
         required int32 number    = 2;
     }
-    required string     first_name    = 1; 
-    required string     last_name     = 2; 
-    required int32      date_of_birth = 3;
+    required string     first_name    = 1 [default = "Max"]; 
+    required string     last_name     = 2 [default = "Ransan"]; 
+    required int32      date_of_birth = 3 [default = 19820429];
     optional TelNumber  tel_number    = 4;  
 
     oneof Employment {

--- a/src/integration-tests/test01_ml.ml
+++ b/src/integration-tests/test01_ml.ml
@@ -2,34 +2,34 @@
 module T  = Test01_pb
 
 
-let decode_ref_data () = {
-    T.p1 = {
-      T.first_name = "John";
-      T.last_name  = "Doe";
-      T.date_of_birth = 19820429; 
-      T.tel_number = None; 
-      T.employment = T.Employed_by "Google";
-      T.marital_status = None; 
-      T.gender = Some T.Male;
+let decode_ref_data () = T.({
+    p1 = {
+      first_name = "John";
+      last_name  = "Doe";
+      date_of_birth = 19820429; 
+      tel_number = None; 
+      employment = Employed_by "Google";
+      marital_status = None; 
+      gender = Some Male;
     }; 
-    T.p2 = {
-      T.first_name = "Marie";
-      T.last_name  = "Dupont";
-      T.date_of_birth = 19820306; 
-      T.tel_number = Some {T.area_code = 917; T.number = 1111111};
-      T.employment = T.Employed_by "INRIA";
-      T.marital_status = None;
-      T.gender = Some T.Female;
+    p2 = {
+      first_name = "Marie";
+      last_name  = "Dupont";
+      date_of_birth = 19820306; 
+      tel_number = Some {area_code = 917; number = 1111111};
+      employment = Employed_by "INRIA";
+      marital_status = None;
+      gender = Some Female;
     };
-    T.contact_numbers = {
-      T.area_code = 917;
-      T.number    = 123450;
+    contact_numbers = {
+      area_code = 917;
+      number    = 123450;
     } :: {
-      T.area_code = 917;
-      T.number    = 123451;
+      area_code = 917;
+      number    = 123451;
     } :: []; 
-    T.number_of_children = None; 
-  } 
+    number_of_children = None; 
+  }) 
 
    
 
@@ -42,4 +42,16 @@ let () =
       Test_util.decode "test01.c2ml.data" T.decode_couple T.string_of_couple (decode_ref_data  ()) 
   | Test_util.Encode -> 
       Test_util.encode "test01.ml2c.data" T.encode_couple (decode_ref_data ())
+let () = 
+
+  let expected_default_person = T.({
+    first_name = "Max";
+    last_name = "Ransan";
+    date_of_birth  = 19820429;
+    tel_number = None;
+    employment = Self_employed 0; 
+    marital_status = None; 
+    gender = None;
+  }) in
+  assert (expected_default_person = T.default_person)
 

--- a/src/lib/encoding_util.ml
+++ b/src/lib/encoding_util.ml
@@ -14,6 +14,7 @@ type field_encoding = {
   field_number: int; 
   payload_kind: payload_kind; 
   nested: bool;
+  default: Pbpt.constant option;
 }
 
 let string_of_payload_kind = function 
@@ -48,4 +49,5 @@ let encoding_of_field_type all_types (field:(Pbtt.resolved, 'a) Pbtt.field) =
     payload_kind = pk;
     nested; 
     field_number = Pbtt_util.field_number field;
+    default = Pbtt_util.field_default field;
   }

--- a/src/lib/encoding_util.mli
+++ b/src/lib/encoding_util.mli
@@ -14,6 +14,7 @@ type field_encoding = {
   field_number : int; 
   payload_kind : payload_kind; 
   nested : bool;
+  default: Pbpt.constant option;
 }
 
 val string_of_payload_kind : payload_kind -> string 

--- a/src/lib/pbtt_util.ml
+++ b/src/lib/pbtt_util.ml
@@ -14,6 +14,8 @@ let field_type {Pbtt.field_type; _ } =
 let field_label {Pbtt.field_parsed = {Pbpt.field_label; _ }; _ } = 
   field_label 
 
+let field_default {Pbtt.field_default; _ } = field_default 
+
 let empty_scope  = { 
   Pbtt.packages = []; 
   message_names = [] 

--- a/src/lib/pbtt_util.mli
+++ b/src/lib/pbtt_util.mli
@@ -21,6 +21,9 @@ val field_type   : ('a, 'b)  Pbtt.field -> 'a Pbtt.field_type
 val field_label  : ('a, 'b)  Pbtt.field -> 'b 
 (** [field_label field] returns the label of [field] *)
 
+val field_default : ('a, 'b)  Pbtt.field -> Pbpt.constant option
+(** [field_default field] returns the default value of [field] *)
+
 val type_of_id : 'a Pbtt.proto -> int -> 'a Pbtt.proto_type 
 (** [type_of_id all_types id] returns the type associated with the given id, 
     @raise [Not_found] if the type is not in the all_types. 


### PR DESCRIPTION
In this PR the basic support for default field option ( `[default = <...>]`) is added. Message field of basic types are supported. Functionality is missing for the default value of enums. 