### PR TITLE
Add message level option support in frontend

### DIFF
--- a/src/compilerlib/pbparser.mly
+++ b/src/compilerlib/pbparser.mly
@@ -92,8 +92,8 @@
 %start import_ 
 %type <Pbpt.import> import_
 
-%start file_option_
-%type <Pbpt.file_option> file_option_
+%start option_
+%type <Pbpt.file_option> option_
 
 %start extension_range_list_
 %type <Pbpt.extension_range list> extension_range_list_
@@ -115,7 +115,7 @@ enum_            : enum          EOF {$1}
 oneof_           : oneof         EOF {$1} 
 message_         : message       EOF {$1} 
 import_          : import        EOF {$1} 
-file_option_     : file_option   EOF {$1} 
+option_          : option   EOF {$1} 
 extension_range_list_ : extension_range_list EOF {$1}
 extension_       : extension    EOF {$1}
 extend_          : extend       EOF {$1}
@@ -130,14 +130,14 @@ proto:
 
 proto_content:
   | import              {Pbpt_util.proto ~import:$1  ()}
-  | file_option         {Pbpt_util.proto ~file_option:$1  ()}
+  | option              {Pbpt_util.proto ~file_option:$1  ()}
   | package_declaration {Pbpt_util.proto ~package:$1 ()}
   | message             {Pbpt_util.proto ~message:$1 ()}
   | enum                {Pbpt_util.proto ~enum:$1 ()}
   | extend              {Pbpt_util.proto ~extend:$1 ()}
 
   | import              proto {Pbpt_util.proto ~import:$1  ~proto:$2 ()}
-  | file_option         proto {Pbpt_util.proto ~file_option:$1  ~proto:$2 ()}
+  | option              proto {Pbpt_util.proto ~file_option:$1  ~proto:$2 ()}
   | package_declaration proto {Pbpt_util.proto ~package:$1 ~proto:$2 ()}
   | message             proto {Pbpt_util.proto ~message:$1 ~proto:$2 ()}
   | enum                proto {Pbpt_util.proto ~enum:$1 ~proto:$2 ()}
@@ -173,6 +173,7 @@ message_body_content :
   | message      { Pbpt_util.message_body_sub $1 }
   | enum         { Pbpt_util.message_body_enum $1 }
   | extension    { Pbpt_util.message_body_extension $1 }
+  | option       { Pbpt_util.message_body_option $1 }
   | error        { Exception.syntax_error ()}
 
 extend : 
@@ -278,16 +279,16 @@ field_option :
   | IDENT EQUAL constant               { (snd $1, $3) } 
   | LPAREN IDENT RPAREN EQUAL constant { (snd $2, $5)} 
 
-file_option_identifier_item :
+option_identifier_item :
   | IDENT                   {snd $1}
   | LPAREN IDENT RPAREN     {snd $2}
 
-file_option_identifier : 
-  | file_option_identifier_item    {$1}
-  | file_option_identifier IDENT   {$1 ^ (snd $2)}
+option_identifier : 
+  | option_identifier_item    {$1}
+  | option_identifier IDENT   {$1 ^ (snd $2)}
 
-file_option :
-  | OPTION file_option_identifier EQUAL constant semicolon { ($2, $4) }
+option :
+  | OPTION option_identifier EQUAL constant semicolon { ($2, $4) }
 
 constant : 
   | INT        { Pbpt.Constant_int $1 }

--- a/src/compilerlib/pbpt.ml
+++ b/src/compilerlib/pbpt.ml
@@ -38,11 +38,13 @@ type constant =
 
     [required int32 my_field = [default=1]]
   *) 
-type field_option = string * constant 
+type option_ = string * constant 
 
-type field_options = field_option list 
+type field_options = option_ list 
 
-type file_option = field_option 
+type file_option = option_
+
+type message_option = option_ 
 
 (** A field property defining its occurence
  *)
@@ -114,6 +116,7 @@ type message_body_content =
   | Message_sub of message 
   | Message_enum of enum 
   | Message_extension of extension_range list 
+  | Message_option of message_option 
 
 (** Message entity. 
  

--- a/src/compilerlib/pbpt_util.ml
+++ b/src/compilerlib/pbpt_util.ml
@@ -83,6 +83,7 @@ let message_body_oneof_field field =  Pbpt.Message_oneof_field   field
 let message_body_sub message  =  Pbpt.Message_sub message 
 let message_body_enum enum = Pbpt.Message_enum enum
 let message_body_extension extension_ranges = Pbpt.Message_extension extension_ranges 
+let message_body_option option_ = Pbpt.Message_option option_ 
 
 let message ~content message_name = 
   incr message_counter;

--- a/src/compilerlib/pbpt_util.mli
+++ b/src/compilerlib/pbpt_util.mli
@@ -95,6 +95,10 @@ val message_body_extension:
   Pbpt.extension_range list  -> 
   Pbpt.message_body_content
 
+val message_body_option : 
+  Pbpt.message_option -> 
+  Pbpt.message_body_content
+
 val message : 
   content:Pbpt.message_body_content list -> 
   string -> 

--- a/src/compilerlib/pbtt.ml
+++ b/src/compilerlib/pbtt.ml
@@ -141,6 +141,7 @@ type 'a message_body_content =
 
 and 'a message = {
   extensions : Pbpt.extension_range list;
+  options : Pbpt.message_option list;
   message_name : string; 
   message_body : 'a message_body_content list; 
 }

--- a/src/include/ocaml-protoc/ocamloptions.proto
+++ b/src/include/ocaml-protoc/ocamloptions.proto
@@ -16,6 +16,11 @@ extend google.protobuf.FieldOptions {
 }
 
 extend google.protobuf.FileOptions {
-    optional OCamlType int32_type = 100002;
-    optional OCamlType int64_type = 100003;
+    optional OCamlType int32_type   = 100002;
+    optional OCamlType int64_type   = 100003;
+    optional string ocaml_file_ppx  = 100004;
+}
+
+extend google.protobuf.MessageOptions {
+    optional string ocaml_type_ppx  = 100002;
 }

--- a/src/tests/integration-tests/test20.proto
+++ b/src/tests/integration-tests/test20.proto
@@ -1,0 +1,8 @@
+import "ocamloptions.proto";
+
+option (ocaml_file_ppx) = "@@@file_level_ppx"; 
+
+message M {
+    option (ocaml_type_ppx) = "@@type_level_ppx"; 
+    required int32 f = 1;
+}

--- a/src/tests/integration-tests/test20_cpp.cpp
+++ b/src/tests/integration-tests/test20_cpp.cpp
@@ -1,0 +1,35 @@
+#include <test20.pb.h>
+
+#include <test_util.h>
+
+#include <iostream>
+#include <fstream>
+
+M create_m() {
+    M m;
+    m.set_f(1); 
+
+    return m;
+}
+
+int main(int argc, char const* const argv[]) {
+
+    check_argv(argc, argv); 
+
+    std::string mode(argv[1]);
+
+    if(mode == "encode") {
+        return encode_to_file(create_m(), "test20.c2ml.data");
+    }
+    else if(mode == "decode") {
+        M m; 
+        validate_decode(m, "test20.ml2c.data");
+    }
+    else {
+        std::cerr << "Invalid second argument: " 
+                  << argv[1]
+                  << std::endl;
+        return 1;
+    }
+}
+

--- a/src/tests/integration-tests/test20_ml.ml
+++ b/src/tests/integration-tests/test20_ml.ml
@@ -1,0 +1,14 @@
+module T  = Test20_pb
+
+let decode_ref_data () = 
+  {T.f = 1l}
+ 
+let () = 
+
+  let mode   = Test_util.parse_args () in 
+
+  match mode with 
+  | Test_util.Decode -> 
+      Test_util.decode "test20.c2ml.data" T.decode_m T.pp_m (decode_ref_data ()) 
+  | Test_util.Encode -> 
+      Test_util.encode "test20.ml2c.data" T.encode_m (decode_ref_data ())

--- a/src/tests/unit-tests/parse_file_options.ml
+++ b/src/tests/unit-tests/parse_file_options.ml
@@ -1,5 +1,5 @@
 let parse s  = 
-  Pbparser.file_option_ Pblexer.lexer (Lexing.from_string s)
+  Pbparser.option_ Pblexer.lexer (Lexing.from_string s)
 
 let parse_proto s  = 
   Pbparser.proto_ Pblexer.lexer (Lexing.from_string s)


### PR DESCRIPTION
This PR adds the support for message level option in the Compiler frontend as discussed in #84 
* parser
* parse tree
* typed tree

This allows the following code to validate:
```proto
import "ocamloptions.proto";
option (ocaml_file_ppx) = "@@@file_level_ppx"; 
message M {
    option (ocaml_type_ppx) = "@@type_level_ppx"; 
    required int32 f = 1;
}
```
However for now it is not incorporated by the compiler backend in the code generator (next step). 

