### PR TITLE
Handle ppx extension option

### DIFF
--- a/Makefile.test
+++ b/Makefile.test
@@ -80,7 +80,7 @@ $(INTEGRATION_TESTS_DIR)/test10_cpp.tsk: \
 	export OCAMLRUNPARAM="b" && $(ML_PROTOC) -I $(INTEGRATION_TESTS_DIR) -ml_out $(INTEGRATION_TESTS_DIR) $<
  
 %_ml.native: %_pb.mli %_pb.ml %_ml.ml 
-	$(OCB) -tag debug -I $(INTEGRATION_TESTS_DIR) -pkg unix $@ 
+	$(OCB) -pkg ppx_deriving.show -tag debug -I $(INTEGRATION_TESTS_DIR) -pkg unix $@ 
 
 test%: bin.native bin.byte \
 	   $(INTEGRATION_TESTS_DIR)/test%_ml.native \
@@ -102,7 +102,7 @@ testCompat: $(INTEGRATION_TESTS_DIR)/test03_cpp.tsk $(INTEGRATION_TESTS_DIR)/tes
 
 integration: test01 test02 test05 test06 test07 test08 test09 test10 \
 	         test11 test12 test13 test14 test15 test16 test17 test18 \
-			 test19 testCompat 
+			 test19 test20 testCompat 
 
 #
 # Google Unittest 

--- a/src/compilerlib/exception.ml
+++ b/src/compilerlib/exception.ml
@@ -83,6 +83,7 @@ type error =
   | Invalid_field_label of Loc.t 
   | Missing_field_label of Loc.t 
   | Parsing_error of string * int * string 
+  | Invalid_ppx_extension_option of string 
   | Syntax_error
 
 
@@ -153,6 +154,9 @@ let prepare_error = function
   | Invalid_mutable_option field_name -> 
     P.sprintf "Invalid mutable option for field %s" (Util.option_default ""
     field_name) 
+  
+  | Invalid_ppx_extension_option message_name -> 
+    P.sprintf "Invalid ppx extension value for message: %s, string expected" message_name
 
 
 let add_loc loc exn  = 
@@ -233,6 +237,9 @@ let invalid_field_label loc =
 
 let missing_field_label loc = 
   raise (Compilation_error (Missing_field_label loc))
+  
+let invalid_ppx_extension_option message_name = 
+  raise (Compilation_error (Invalid_ppx_extension_option message_name)) 
 
 let syntax_error () = 
   raise (Compilation_error Syntax_error) 

--- a/src/compilerlib/exception.mli
+++ b/src/compilerlib/exception.mli
@@ -88,4 +88,6 @@ val invalid_field_label : Loc.t -> 'a
 
 val missing_field_label : Loc.t -> 'a 
 
+val invalid_ppx_extension_option : string -> 'a 
+
 val syntax_error : unit  -> 'a 

--- a/src/compilerlib/ocaml/codegen_encode.ml
+++ b/src/compilerlib/ocaml/codegen_encode.ml
@@ -6,8 +6,8 @@ module L = Logger
 
 open Codegen_util
 
-let constructor_name s =
-  String.capitalize @@ String.lowercase s 
+let constructor_name s = 
+  (String.capitalize @@ String.lowercase s) [@@ocaml.warning "-3"] 
 
 let gen_encode_field_key sc number pk is_packed = 
   F.line sc @@ sp "Pbrt.Encoder.key (%i, Pbrt.%s) encoder; " 

--- a/src/compilerlib/ocaml/codegen_type.ml
+++ b/src/compilerlib/ocaml/codegen_type.ml
@@ -73,16 +73,28 @@ let gen_type_const_variant ?and_ {T.cv_name; cv_constructors} sc =
     ) cv_constructors;
   )
 
+let print_ppx_extension {T.type_level_ppx_extension; _ } sc = 
+  match type_level_ppx_extension with
+  | None -> () 
+  | Some ppx_content -> F.line sc @@ sp "[%s]" ppx_content
+
 let gen_struct ?and_ t scope = 
   begin
     match t with 
     | {T.spec = T.Record r; _ } -> (
       gen_type_record  ?and_ r scope; 
+      print_ppx_extension t scope; 
       F.empty_line scope;
       gen_type_record ~mutable_:() ~and_:() r scope 
     ) 
-    | {T.spec = T.Variant v; _ } -> gen_type_variant  ?and_ v scope  
-    | {T.spec = T.Const_variant v; _ } -> gen_type_const_variant ?and_ v scope 
+
+    | {T.spec = T.Variant v; _ } -> 
+      gen_type_variant  ?and_ v scope;  
+      print_ppx_extension t scope; 
+
+    | {T.spec = T.Const_variant v; _ } -> 
+      gen_type_const_variant ?and_ v scope; 
+      print_ppx_extension t scope; 
   end; 
   true
 
@@ -95,6 +107,7 @@ let gen_sig ?and_ t scope =
     | {T.spec = T.Variant v; _ } -> gen_type_variant  ?and_ v scope  
     | {T.spec = T.Const_variant v; _ } -> gen_type_const_variant ?and_ v scope 
   end; 
+  print_ppx_extension t scope; 
   true
 
 let ocamldoc_title = "Types"

--- a/src/compilerlib/ocaml/codegen_util.ml
+++ b/src/compilerlib/ocaml/codegen_util.ml
@@ -85,5 +85,5 @@ let string_of_payload_kind ?capitalize payload_kind packed =
   in 
   match capitalize with
   | None -> s 
-  | Some () -> String.capitalize s 
+  | Some () -> String.capitalize s [@@ocaml.warning "-3"] 
 

--- a/src/compilerlib/ocaml/ocaml_types.ml
+++ b/src/compilerlib/ocaml/ocaml_types.ml
@@ -126,4 +126,5 @@ and type_spec =
 type type_ = {
   module_ : string; (* For now limit to a single module *)  
   spec : type_spec; 
+  type_level_ppx_extension : string option; 
 }

--- a/src/compilerlib/pbpt_util.ml
+++ b/src/compilerlib/pbpt_util.ml
@@ -127,6 +127,7 @@ let rec message_printer ?level:(level = 0) {
         prefix (); Printf.printf "- enum type [%s]\n" enum_name 
     | Pbpt.Message_sub m -> message_printer ~level:(level + 2) m
     | Pbpt.Message_extension _ -> () 
+    | Pbpt.Message_option _ -> ()
   ) message_body 
 
 let proto ?syntax ?file_option ?package ?import ?message ?enum ?proto ?extend () = 

--- a/src/compilerlib/pbtt.ml
+++ b/src/compilerlib/pbtt.ml
@@ -141,7 +141,7 @@ type 'a message_body_content =
 
 and 'a message = {
   extensions : Pbpt.extension_range list;
-  options : Pbpt.message_option list;
+  message_options : Pbpt.message_option list;
   message_name : string; 
   message_body : 'a message_body_content list; 
 }
@@ -154,6 +154,7 @@ type enum_value = {
 type enum = {
   enum_name : string; 
   enum_values: enum_value list; 
+  enum_options : Pbpt.message_option list; 
 }
 
 type 'a proto_type_spec = 

--- a/src/compilerlib/pbtt_util.mli
+++ b/src/compilerlib/pbtt_util.mli
@@ -66,6 +66,10 @@ val type_of_id : 'a Pbtt.proto -> int -> 'a Pbtt.proto_type
 
 val string_of_message : int -> Pbtt.type_scope -> 'a Pbtt.message -> string 
 
+val message_option : 'a Pbtt.message -> string -> Pbpt.constant option 
+
+val enum_option : Pbtt.enum -> string -> Pbpt.constant option 
+
 (** {2 Accessor for Pbtt.type *) 
 
 val type_id_of_type : 'a Pbtt.proto_type -> int 
@@ -134,6 +138,7 @@ val compile_message_p2:
   Pbtt.resolved Pbtt.message 
 
 val compile_message_p1 : 
+  ?parent_options:Pbpt.message_option list ->
   string -> 
   Pbpt.file_option list ->
   Pbtt.type_scope -> 

--- a/src/tests/integration-tests/test20.proto
+++ b/src/tests/integration-tests/test20.proto
@@ -2,7 +2,17 @@ import "ocamloptions.proto";
 
 option (ocaml_file_ppx) = "@@@file_level_ppx"; 
 
+
 message M {
-    option (ocaml_type_ppx) = "@@type_level_ppx"; 
-    required int32 f = 1;
+  option (ocaml_type_ppx) = "@@deriving show"; 
+  enum E {
+    EONE = 1; 
+    ETWO = 2;
+  }
+  required int32 f1 = 1;
+  message Sub {
+    required int32 sub_f1 = 1;
+  }
+  required Sub f2 = 2; 
+  required E f3 = 3;
 }

--- a/src/tests/integration-tests/test20_cpp.cpp
+++ b/src/tests/integration-tests/test20_cpp.cpp
@@ -7,8 +7,9 @@
 
 M create_m() {
     M m;
-    m.set_f(1); 
-
+    m.set_f1(1); 
+    m.mutable_f2()->set_sub_f1(2);
+    m.set_f3(M_E_EONE);
     return m;
 }
 

--- a/src/tests/integration-tests/test20_ml.ml
+++ b/src/tests/integration-tests/test20_ml.ml
@@ -1,7 +1,10 @@
 module T  = Test20_pb
 
 let decode_ref_data () = 
-  {T.f = 1l}
+  {T.f1 = 1l; f2 = {T.sub_f1 = 2l}; f3 = Eone}
+
+let () = 
+  Printf.printf "Show is working: %s\n" @@ T.show_m (decode_ref_data ())
  
 let () = 
 


### PR DESCRIPTION
With this PR we implement a large majority of the use case for supporting PPX entension as discussed in #84 

The feature missing are:
* File level enum: right now protobuf option are not supported for enum. However if the enum is defined in a message, the message option will be in scope for the enum and ppx option will be propagated down. 
* Field level ppx option: Only message level is supported. 

Here is an example of what is  supported:
```proto
message M {
  option (ocaml_type_ppx) = "@@deriving show"; 
  enum E {
    EONE = 1; 
    ETWO = 2;
  }
  required int32 f1 = 1;
  message Sub {
    required int32 sub_f1 = 1;
  }
  required Sub f2 = 2; 
  required E f3 = 3;
}
```

Which would generate:
```OCaml
type m_e =
  | Eone 
  | Etwo 
[@@deriving show]

type m_sub = {
  sub_f1 : int32;
}
[@@deriving show]

type m = {
  f1 : int32;
  f2 : m_sub;
  f3 : m_e;
}
[@@deriving show]
```