### PR TITLE
Add ppx extension support for enum protobuf type

### DIFF
--- a/src/compilerlib/ocaml/backend_ocaml.ml
+++ b/src/compilerlib/ocaml/backend_ocaml.ml
@@ -494,7 +494,7 @@ let compile_enum file_name scope ({Pbtt.enum_name; Pbtt.enum_values; enum_option
     (constructor_name enum_value_name,  enum_value_int)
   ) enum_values in 
   let type_level_ppx_extension = 
-    type_level_ppx_extension enum_name @@ Pbtt_util.enum_option enum "ocaml_type_ppx" 
+    type_level_ppx_extension enum_name @@ Pbtt_util.enum_option enum "ocaml_enum_ppx" 
   in
   OCaml_types.({
     module_; 

--- a/src/compilerlib/pbparser.mly
+++ b/src/compilerlib/pbparser.mly
@@ -75,7 +75,7 @@
 %type <Pbpt.field_label Pbpt.field> normal_field_
 
 %start enum_value_ 
-%type <Pbpt.enum_value> enum_value_
+%type <Pbpt.enum_body_content> enum_value_
 
 %start enum_
 %type <Pbpt.enum> enum_
@@ -115,7 +115,7 @@ enum_            : enum          EOF {$1}
 oneof_           : oneof         EOF {$1} 
 message_         : message       EOF {$1} 
 import_          : import        EOF {$1} 
-option_          : option   EOF {$1} 
+option_          : option        EOF {$1} 
 extension_range_list_ : extension_range_list EOF {$1}
 extension_       : extension    EOF {$1}
 extend_          : extend       EOF {$1}
@@ -265,7 +265,6 @@ label :
   | REQUIRED { `Required }  
   | REPEATED { `Repeated }
   | OPTIONAL { `Optional }
-  | IDENT    { Exception.invalid_field_label (fst $1) } /* HT */
 
 field_options : 
   | LBRACKET field_option_list RBRACKET { $2 }; 
@@ -302,11 +301,15 @@ constant :
   | STRING     { Pbpt.Constant_string $1 }; 
 
 enum:
-  | ENUM IDENT LBRACE enum_values rbrace {Pbpt_util.enum ~enum_values:$4 (snd $2) } 
+  | ENUM IDENT LBRACE enum_values rbrace { Pbpt_util.enum ~enum_body:$4 (snd $2) } 
 
 enum_values:
-  |                              { [] }
-  | enum_value enum_values       { $1::$2 }; 
+  |                                { [] }
+  | enum_body_content enum_values  { $1::$2 }
+
+enum_body_content :
+  | option     { Pbpt_util.enum_option $1 }
+  | enum_value { $1 }
 
 enum_value : 
   | IDENT EQUAL INT semicolon  { Pbpt_util.enum_value ~int_value:$3 (snd $1) } 

--- a/src/compilerlib/pbpt.ml
+++ b/src/compilerlib/pbpt.ml
@@ -90,10 +90,14 @@ type enum_value = {
   enum_value_int : int;
 }
 
+type enum_body_content =
+  | Enum_value of enum_value
+  | Enum_option of option_
+
 type enum = {
   enum_id  : int; 
   enum_name : string; 
-  enum_values : enum_value list; 
+  enum_body : enum_body_content list; 
 } 
 
 type extension_range_to = 

--- a/src/compilerlib/pbpt_util.ml
+++ b/src/compilerlib/pbpt_util.ml
@@ -54,17 +54,19 @@ let oneof ~fields name = {
 
 let message_counter = ref 0
 
-let enum_value ~int_value name = { 
-  Pbpt.enum_value_name = name; 
-  Pbpt.enum_value_int = int_value; 
-}
+let enum_value ~int_value name = Pbpt.(Enum_value { 
+  enum_value_name = name; 
+  enum_value_int = int_value; 
+})
 
-let enum ?enum_values:(enum_values = []) enum_name =
+let enum_option option_ = Pbpt.Enum_option option_ 
+
+let enum ?enum_body:(enum_body= []) enum_name =
   incr message_counter; 
   {
     Pbpt.enum_id  = !message_counter; 
     Pbpt.enum_name; 
-    Pbpt.enum_values; 
+    Pbpt.enum_body; 
   } 
 
 let extension_range_single_number number = 

--- a/src/compilerlib/pbpt_util.mli
+++ b/src/compilerlib/pbpt_util.mli
@@ -72,10 +72,14 @@ val message_body_oneof_field  :
 val enum_value :
   int_value:int -> 
   string -> 
-  Pbpt.enum_value 
+  Pbpt.enum_body_content
+
+val enum_option :
+  Pbpt.option_ -> 
+  Pbpt.enum_body_content
 
 val enum : 
-  ?enum_values:Pbpt.enum_value list -> 
+  ?enum_body:Pbpt.enum_body_content list -> 
   string -> 
   Pbpt.enum 
 

--- a/src/include/ocaml-protoc/ocamloptions.proto
+++ b/src/include/ocaml-protoc/ocamloptions.proto
@@ -24,3 +24,7 @@ extend google.protobuf.FileOptions {
 extend google.protobuf.MessageOptions {
     optional string ocaml_type_ppx  = 100002;
 }
+
+extend google.protobuf.EnumOptions {
+    optional string ocaml_enum_ppx  = 100002;
+}

--- a/src/tests/integration-tests/test20.proto
+++ b/src/tests/integration-tests/test20.proto
@@ -2,13 +2,14 @@ import "ocamloptions.proto";
 
 option (ocaml_file_ppx) = "@@@file_level_ppx"; 
 
+enum E {
+  option (ocaml_enum_ppx) = "@@deriving show"; 
+  EONE = 1; 
+  ETWO = 2;
+}
 
 message M {
   option (ocaml_type_ppx) = "@@deriving show"; 
-  enum E {
-    EONE = 1; 
-    ETWO = 2;
-  }
   required int32 f1 = 1;
   message Sub {
     required int32 sub_f1 = 1;

--- a/src/tests/integration-tests/test20_cpp.cpp
+++ b/src/tests/integration-tests/test20_cpp.cpp
@@ -9,7 +9,7 @@ M create_m() {
     M m;
     m.set_f1(1); 
     m.mutable_f2()->set_sub_f1(2);
-    m.set_f3(M_E_EONE);
+    m.set_f3(EONE);
     return m;
 }
 


### PR DESCRIPTION
The following is now supported

```proto
enum E {
  option (ocaml_enum_ppx) = "@@deriving show"; 
  EONE = 1; 
  ETWO = 2;
}

message M {
  option (ocaml_type_ppx) = "@@deriving show"; 
  required int32 f1 = 1;
  message Sub {
    required int32 sub_f1 = 1;
  }
  required Sub f2 = 2; 
  required E f3 = 3;
}
```