### PR TITLE
Allow field label to be optional as per proto3 syntax

### DIFF
--- a/src/compilerlib/pbparser.mly
+++ b/src/compilerlib/pbparser.mly
@@ -236,10 +236,10 @@ normal_field :
     Pbpt_util.field ~label:$1 ~type_:(snd $2) ~number:$5 $3 
   } 
   | IDENT field_name EQUAL INT field_options semicolon { 
-    Exception.missing_field_label (fst $1) 
+    Pbpt_util.field ~label:(`Optional) ~type_:(snd $1) ~number:$4 ~options:$5 $2
   }
   | IDENT field_name EQUAL INT semicolon { 
-    Exception.missing_field_label (fst $1) 
+    Pbpt_util.field ~label:(`Optional) ~type_:(snd $1) ~number:$4 $2 
   }
 
 field_name :


### PR DESCRIPTION
The protobuf version 3 syntax allows the message fields to not have a label, in which case they are considered optional fields. Example

```
syntax = "proto3";

message Person {
  string name = 1;
  int32 id = 2;
  string email = 3;
  repeated string phone = 4;
}
```

This change updates the parser to allow such messages. 

I couldn't figure out how to do this conditionally based on the syntax directive at the beginning of the proto file. Any pointers in the right direction would be nice.
