### PR TITLE
Initial commit for proto3 support

### DIFF
--- a/Makefile.test
+++ b/Makefile.test
@@ -16,6 +16,7 @@ export CPPFLAGS
 
 # unit test of the ocaml-protoc internals  
 unit-tests: 		
+	$(OCB) $(UNIT_TESTS_DIR)/verify_syntax_invariants.native
 	$(OCB) $(UNIT_TESTS_DIR)/parse_extension_range.native
 	$(OCB) $(UNIT_TESTS_DIR)/parse_field_options.native 
 	$(OCB) $(UNIT_TESTS_DIR)/parse_file_options.native 
@@ -29,6 +30,7 @@ unit-tests:
 	$(OCB) $(UNIT_TESTS_DIR)/ocaml_codegen_test.native
 	$(OCB) $(UNIT_TESTS_DIR)/graph_test.native
 	$(OCB) $(UNIT_TESTS_DIR)/pbrt_array.native
+	export OCAMLRUNPARAM="b" && ./verify_syntax_invariants.native
 	./parse_extension_range.native
 	./parse_field_options.native
 	./parse_file_options.native
@@ -52,7 +54,7 @@ unit-tests:
 # implementation
 
 # location of where the Google protoc compiler is installed  
-PB_INSTALL = /usr/local/
+PB_INSTALL = /Users/maximeransan/Documents/protobuf
 PB_HINC    = $(PB_INSTALL)/include/
 PB_LINC    = $(PB_INSTALL)/lib/
 PROTOC     = $(PB_INSTALL)/bin/protoc 

--- a/Makefile.test
+++ b/Makefile.test
@@ -110,7 +110,7 @@ testCompat: $(INTEGRATION_TESTS_DIR)/test03_cpp.tsk $(INTEGRATION_TESTS_DIR)/tes
 
 integration: test01 test02 test05 test06 test07 test08 test09 test10 \
 	           test11 test12 test13 test14 test15 test16 test17 test18 \
-			       test19 test20 test21 testCompat 
+			       test19 test20 test21 test22 testCompat 
 
 #
 # Google Unittest 

--- a/_tags
+++ b/_tags
@@ -2,4 +2,4 @@ true: bin_annot
 true: annot
 true: safe_string
 true: keep_locs
-true: warn(A-4-42-41)
+true: warn(A-4-42-41-48)

--- a/src/compilerlib/exception.mli
+++ b/src/compilerlib/exception.mli
@@ -80,7 +80,7 @@ val invalid_mutable_option : ?field_name:string -> unit -> 'a
 
 val missing_one_of_name : Loc.t -> 'a 
 
-val missing_field_label : Loc.t -> 'a 
+val missing_field_label : field_name:string -> message_name:string -> 'a 
 
 val invalid_ppx_extension_option : string -> 'a 
 
@@ -89,3 +89,21 @@ val ocamlyacc_parsing_error : Loc.t -> 'a
 val protoc_parsing_error : error -> Loc.t -> 'a 
 
 val unknown_parsing_error : string -> Loc.t -> 'a 
+
+val invalid_protobuf_syntax : string -> 'a 
+
+val invalid_proto3_field_label : 
+  field_name:string -> 
+  message_name:string -> 
+  'a 
+
+val default_field_option_not_supported : 
+  field_name:string -> 
+  message_name:string -> 
+  'a 
+
+val invalid_first_enum_value_proto3 :
+  ?message_name:string -> 
+  enum_name:string -> 
+  unit ->
+  'a

--- a/src/compilerlib/ocaml/backend_ocaml.ml
+++ b/src/compilerlib/ocaml/backend_ocaml.ml
@@ -408,6 +408,7 @@ let compile_message
         let mutable_  = is_mutable ~field_name field_options in 
 
         let record_field_type = match Pbtt_util.field_label field with
+          | `Nolabel -> OCaml_types.Rft_nolabel (field_type, encoding_number, pk)
           | `Required -> OCaml_types.Rft_required (field_type, encoding_number, pk, field_default) 
           | `Optional -> OCaml_types.Rft_optional (field_type, encoding_number, pk, field_default) 
           | `Repeated -> 

--- a/src/compilerlib/ocaml/codegen_decode.ml
+++ b/src/compilerlib/ocaml/codegen_decode.ml
@@ -46,6 +46,13 @@ let gen_decode_record ?and_ {T.r_name; r_fields} sc =
     );
     F.line sc ")"
   in
+  
+  let process_nolabel_field sc rf_label (field_type, encoding_number, pk) = 
+    process_field_common sc encoding_number (string_of_nonpacked_pk pk) (fun sc -> 
+      F.line sc @@ sp "v.%s <- %s;" 
+        rf_label (decode_field_f field_type pk); 
+    ) 
+  in
 
   let process_required_field sc rf_label (field_type, encoding_number, pk, _) = 
     process_field_common sc encoding_number (string_of_nonpacked_pk pk) (fun sc -> 
@@ -193,6 +200,7 @@ let gen_decode_record ?and_ {T.r_name; r_fields} sc =
        * .proto file. Unknown fields are ignored. *)
       List.iter (fun {T.rf_label; rf_field_type; _ } -> 
         match rf_field_type with
+        | T.Rft_nolabel x -> process_nolabel_field sc rf_label x 
         | T.Rft_required x -> process_required_field sc rf_label x 
         | T.Rft_optional x -> process_optional_field sc rf_label x 
         | T.Rft_repeated_field x -> process_repeated_field sc rf_label x 

--- a/src/compilerlib/ocaml/codegen_default.ml
+++ b/src/compilerlib/ocaml/codegen_default.ml
@@ -17,7 +17,7 @@ let default_value_of_basic_type ?field_name basic_type field_default =
   | T.Bt_int32 , Some (Pbpt.Constant_int i) -> sp "%il" i
   | T.Bt_int64 , None -> "0L"
   | T.Bt_int64 , Some (Pbpt.Constant_int i) -> sp "%iL" i
-  | T.Bt_bytes , None -> "Bytes.create 64"  
+  | T.Bt_bytes , None -> "Bytes.create 0"  
   | T.Bt_bytes , Some (Pbpt.Constant_string s) -> sp "Bytes.of_string \"%s\"" s  
   | T.Bt_bool  , None -> "false"
   | T.Bt_bool  , Some (Pbpt.Constant_bool b) -> string_of_bool b
@@ -48,6 +48,8 @@ let record_field_default_info record_field : (string * string * string) =
   in
 
   let default_value = match rf_field_type with
+    | T.Rft_nolabel (field_type, _, _) ->
+      dfvft field_type None 
     | T.Rft_required (field_type, _, _, default_value) ->
       dfvft field_type default_value 
     | T.Rft_optional (field_type, _, _, default_value) -> 

--- a/src/compilerlib/ocaml/codegen_encode.ml
+++ b/src/compilerlib/ocaml/codegen_encode.ml
@@ -52,6 +52,7 @@ let gen_encode_record ?and_ {T.r_name; r_fields } sc =
       let {T.rf_label; rf_field_type; _ } = record_field in  
 
       match rf_field_type with 
+      | T.Rft_nolabel (field_type, encoding_number, pk)
       | T.Rft_required (field_type, encoding_number, pk, _) -> ( 
         let var_name = sp "v.%s" rf_label in 
         gen_encode_field_type ~with_key:() sc var_name encoding_number pk false (* packed *) field_type

--- a/src/compilerlib/ocaml/codegen_pp.ml
+++ b/src/compilerlib/ocaml/codegen_pp.ml
@@ -26,6 +26,7 @@ let gen_pp_record  ?and_ {T.r_name; r_fields} sc =
         let var_name = sp "v.%s" rf_label in 
         match rf_field_type with 
 
+        | T.Rft_nolabel (field_type, _, _)
         | T.Rft_required (field_type, _, _, _) -> ( 
           let field_string_of = gen_pp_field field_type in 
           F.line sc @@ sp 

--- a/src/compilerlib/ocaml/codegen_type.ml
+++ b/src/compilerlib/ocaml/codegen_type.ml
@@ -14,6 +14,7 @@ let gen_type_record ?mutable_ ?and_ {T.r_name; r_fields } sc =
   in 
 
   let is_imperative_type = function
+    | T.Rft_nolabel _ 
     | T.Rft_required _ 
     | T.Rft_optional _ 
     | T.Rft_variant_field _ 

--- a/src/compilerlib/ocaml/codegen_util.ml
+++ b/src/compilerlib/ocaml/codegen_util.ml
@@ -34,6 +34,7 @@ let string_of_associative_type = function
   | T.At_hashtable -> "Hashtbl.t"
 
 let string_of_record_field_type = function
+  | T.Rft_nolabel (field_type, _, _)
   | T.Rft_required (field_type, _, _, _) -> 
       string_of_field_type field_type
   | T.Rft_optional (field_type, _, _, _) -> 

--- a/src/compilerlib/ocaml/ocaml_types.ml
+++ b/src/compilerlib/ocaml/ocaml_types.ml
@@ -73,6 +73,9 @@ type encoding_number = int
 type is_packed = bool 
 
 type record_field_type = 
+  | Rft_nolabel         of (field_type * encoding_number * payload_kind) 
+                           (* no default values in proto3 no label fields *)
+
   | Rft_required        of (field_type * encoding_number * payload_kind * default_value)  
   
   | Rft_optional        of (field_type * encoding_number * payload_kind * default_value) 

--- a/src/compilerlib/pbparser.mly
+++ b/src/compilerlib/pbparser.mly
@@ -242,10 +242,10 @@ normal_field :
     Pbpt_util.field ~label:$1 ~type_:(snd $2) ~number:$5 $3 
   } 
   | IDENT field_name EQUAL INT field_options semicolon { 
-    Exception.missing_field_label (fst $1) 
+    Pbpt_util.field ~label:`Nolabel ~type_:(snd $1) ~number:$4 ~options:$5 $2
   }
   | IDENT field_name EQUAL INT semicolon { 
-    Exception.missing_field_label (fst $1) 
+    Pbpt_util.field ~label:`Nolabel ~type_:(snd $1) ~number:$4 $2
   }
 
 field_name :

--- a/src/compilerlib/pbpt.ml
+++ b/src/compilerlib/pbpt.ml
@@ -52,6 +52,7 @@ type field_label = [
   | `Optional 
   | `Required 
   | `Repeated 
+  | `Nolabel  (** proto3 field which replaces required and optional *)
 ]
 
 type oneof_label = [ `Oneof ] 

--- a/src/compilerlib/pbpt_util.mli
+++ b/src/compilerlib/pbpt_util.mli
@@ -128,6 +128,8 @@ val proto:
   unit -> 
   Pbpt.proto
 
+val verify_syntax_invariants : Pbpt.proto -> unit 
+
 (** {2 Miscellaneous functionality } *)
 
 val message_printer :?level:int -> Pbpt.message -> unit 

--- a/src/ocaml-protoc/ocaml_protoc.ml
+++ b/src/ocaml-protoc/ocaml_protoc.ml
@@ -207,6 +207,7 @@ let compile cmd_line_files_options include_dirs proto_file_name =
       let proto = {proto with 
         Pbpt.file_options = cmd_line_files_options @ proto.Pbpt.file_options
       } in 
+      Pbpt_util.verify_syntax_invariants proto;
       close_in ic; 
       let files_options = (file_name, proto.Pbpt.file_options) :: files_options in 
       let pbtt_msgs = pbtt_msgs @ Pbtt_util.compile_proto_p1 file_name proto in 

--- a/src/tests/integration-tests/test22.proto
+++ b/src/tests/integration-tests/test22.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package foo.bar;  
+
+enum Gender {
+    Male = 0;
+    Female = 1; 
+}
+
+message Person {
+    message TelNumber {
+        int32 area_code = 1;
+        int32 number    = 2;
+    }
+    string     first_name    = 1; 
+    string     last_name     = 2; 
+    int32      date_of_birth = 3;
+    TelNumber  tel_number    = 4;  
+
+    oneof Employment {
+        int32  self_employed = 5; // value is unused  
+        string employed_by   = 6; // value is company name
+    }
+    enum MaritalStatus {
+        Single = 0; 
+        Married = 1; 
+    }
+    MaritalStatus marital_status = 7;
+    Gender gender = 8;  
+}
+
+message Couple {
+    Person p1 = 1;
+    Person p2 = 2; 
+    repeated Person.TelNumber contact_numbers = 3;
+    uint32 number_of_children = 4;
+}

--- a/src/tests/integration-tests/test22_cpp.cpp
+++ b/src/tests/integration-tests/test22_cpp.cpp
@@ -1,0 +1,63 @@
+#include <test22.pb.h>
+
+#include <test_util.h>
+
+#include <iostream>
+
+using namespace foo::bar; 
+
+Couple create_test_couple() {
+    Couple cp; 
+    {
+        Person& p = *cp.mutable_p1();
+        p.set_first_name("John");
+        p.set_last_name("Doe"); 
+        p.set_date_of_birth(19820429);
+        p.set_employed_by("Google");
+        p.set_gender(Male);
+    }
+    {
+        Person& p = *cp.mutable_p2();
+        p.set_first_name("Marie");
+        p.set_last_name("Dupont"); 
+        p.set_date_of_birth(19820306);
+        p.set_employed_by("INRIA");
+        
+        Person_TelNumber& t = *p.mutable_tel_number();
+        t.set_area_code(917);
+        t.set_number(1111111);
+        p.set_gender(Female);
+        p.set_marital_status(Person_MaritalStatus_Married);
+    }
+
+    for(std::size_t i=0; i<2; ++i) {
+        Person_TelNumber& cn = *cp.add_contact_numbers();
+        cn.set_area_code(917);
+        cn.set_number   (123450 + i);
+    }
+
+    return cp;
+}
+
+
+int main(int argc, char const* const argv[]) {
+
+    check_argv(argc, argv);
+
+    std::string mode(argv[1]);
+
+    if(mode == "encode") {
+        return encode_to_file(create_test_couple(), "test01.c2ml.data");
+    }
+    else if(mode == "decode") {
+        Couple cp; 
+        validate_decode(cp, "test01.ml2c.data");
+    }
+    else {
+        std::cerr << "Invalid second argument: " 
+                  << argv[1]
+                  << std::endl;
+        return 1;
+    }
+}
+

--- a/src/tests/integration-tests/test22_ml.ml
+++ b/src/tests/integration-tests/test22_ml.ml
@@ -1,0 +1,53 @@
+module T  = Test22_pb
+
+let decode_ref_data () = T.({
+    p1 = {
+      first_name = "John";
+      last_name  = "Doe";
+      date_of_birth = 19820429l; 
+      tel_number = {area_code = 0l; number = 0l}; 
+      employment = Employed_by "Google";
+      marital_status = Single; 
+      gender = Male;
+    }; 
+    p2 = {
+      first_name = "Marie";
+      last_name  = "Dupont";
+      date_of_birth = 19820306l; 
+      tel_number = {area_code = 917l; number = 1111111l};
+      employment = Employed_by "INRIA";
+      marital_status = Married;
+      gender = Female;
+    };
+    contact_numbers = {
+      area_code = 917l;
+      number    = 123450l;
+    } :: {
+      area_code = 917l;
+      number    = 123451l;
+    } :: []; 
+    number_of_children = 0l;
+  }) 
+
+let () = 
+
+  let mode   = Test_util.parse_args () in 
+
+  match mode with 
+  | Test_util.Decode -> 
+      Test_util.decode "test01.c2ml.data" T.decode_couple T.pp_couple (decode_ref_data  ()) 
+  | Test_util.Encode -> 
+      Test_util.encode "test01.ml2c.data" T.encode_couple (decode_ref_data ())
+let () = 
+
+  let expected_default_person = T.({
+    first_name = "";
+    last_name = "";
+    date_of_birth  = 0l;
+    tel_number = {area_code = 0l; number = 0l};
+    employment = Self_employed 0l; 
+    marital_status = Single; 
+    gender = Male;
+  }) in
+  assert (expected_default_person = T.default_person ())
+

--- a/src/tests/unit-tests/verify_syntax_invariants.ml
+++ b/src/tests/unit-tests/verify_syntax_invariants.ml
@@ -1,0 +1,108 @@
+module E = Exception
+
+let parse s =
+  Pbparser.proto_ Pblexer.lexer (Lexing.from_string s)
+
+(* invalid proto 2 field *) 
+
+let () =
+  let proto = parse "message M { string no_label = 1; }" in  
+  match Pbpt_util.verify_syntax_invariants proto with
+  | () -> assert(false) 
+  | exception E.Compilation_error _ -> () 
+
+(* invalid proto 2 field with setting the syntax explicitely *) 
+
+let () =
+  let proto = parse "\
+    syntax = \"proto2\"; \
+    message M { \
+      string no_label = 1; \
+    }" in  
+
+  match Pbpt_util.verify_syntax_invariants proto with
+  | () -> assert(false) 
+  | exception E.Compilation_error _ -> () 
+
+(* valid proto 3 field *) 
+
+let () =
+  let proto = parse "\
+    syntax = \"proto3\"; \
+    message M { \
+      string no_label = 1; \
+      repeated string r = 2; \
+      message S {\
+        string s_no_label = 3; \
+        repeated string s_r = 4; \
+      } \
+    }" in  
+
+  match Pbpt_util.verify_syntax_invariants proto with
+  | () -> ()
+  | exception E.Compilation_error _ -> assert(false)
+
+(* invalid proto 3 field label *)
+
+let () =
+  let proto = parse "\
+    syntax = \"proto3\"; \
+    message M { \
+      required string no_label = 1; \
+    }" in  
+
+  match Pbpt_util.verify_syntax_invariants proto with
+  | () -> assert(false) 
+  | exception E.Compilation_error _ -> () 
+
+let () =
+  let proto = parse "\
+    syntax = \"proto3\"; \
+    message M { message S { \
+      required string no_label = 1; \
+    }}" in  
+
+  match Pbpt_util.verify_syntax_invariants proto with
+  | () -> assert(false) 
+  | exception E.Compilation_error _ -> () 
+
+(* invalid proto3 first enum value *)
+
+let () =
+  let proto = parse "\
+    syntax = \"proto3\"; \
+    enum E { EN1 = 1; EN2 = 2; } \
+    message M { } \
+    " in  
+
+  match Pbpt_util.verify_syntax_invariants proto with
+  | () -> assert(false) 
+  | exception E.Compilation_error _ -> () 
+
+let () =
+  let proto = parse "\
+    syntax = \"proto3\"; \
+    message M { \
+      enum E { EN1 = 1; EN2 = 2; } \
+    }" in  
+
+  match Pbpt_util.verify_syntax_invariants proto with
+  | () -> assert(false) 
+  | exception E.Compilation_error _ -> () 
+  
+
+(* valid proto3 first enum value *) 
+
+let () =
+  let proto = parse "\
+    syntax = \"proto3\"; \
+    message M { \
+      enum E { EN0 = 0; EN2 = 2; } \
+    }" in  
+
+  match Pbpt_util.verify_syntax_invariants proto with
+  | () -> () 
+  | exception E.Compilation_error _ -> assert(false)
+
+let () =
+  print_endline "Verify syntax invariants ... Ok"


### PR DESCRIPTION
* allow parsing of valid proto3 fields (ie no required nor optional)
* introduce the corresponding `Nolabel` field label and propage
  down the field concept all the way to the code generator.

The only thing missing is the validation for enforcing proto3 syntax.
With this commit, `ocaml-protoc` supports happily the union of proto2
and proto3.