### PR TITLE
Fix readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ let () =
   in 
   
   (* Decode the person and Pretty-print it *)
-  let person = Test14_pb.decode_person (Pbrt.Decoder.of_bytes bytes) in 
-  Format.fprintf Format.std_formatter "%a" Test14_pb.pp_person person
+  let person = Example_pb.decode_person (Pbrt.Decoder.of_bytes bytes) in
+  Format.fprintf Format.std_formatter "%a" Example_pb.pp_person person
 ```
 
 *OCaml users will immediately point to the use of `int32` type in the generated code which might not be the most convenient choice. One can modify this behavior using [custom extensions](doc/ocaml_extensions.md).* 


### PR DESCRIPTION
Use the same module name for both examples