### PR TITLE
Remap tokens following a `T_*` convention.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 *.o
 
 *.sw*
+_build
+
+ocaml-protoc
+ocaml_protoc.byte
+ocaml_protoc.native

--- a/src/compilerlib/pb_parsing_lexer.mll
+++ b/src/compilerlib/pb_parsing_lexer.mll
@@ -1,8 +1,8 @@
 (*
   The MIT License (MIT)
-  
+
   Copyright (c) 2016 Maxime Ransan <maxime.ransan@gmail.com>
-  
+
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights
@@ -25,49 +25,49 @@
 {
 open Pb_parsing_parser
 
-module Loc = Pb_location 
+module Loc = Pb_location
 
-let resolve_identifier loc ident = 
-  match ident, loc with 
-  | "message"    , _   -> MESSAGE 
-  | "required"   , _   -> REQUIRED 
-  | "optional"   , _   -> OPTIONAL 
-  | "repeated"   , _   -> REPEATED
-  | "oneof"      , loc -> ONE_OF loc
-  | "enum"       , _   -> ENUM
-  | "package"    , _   -> PACKAGE
-  | "import"     , loc -> IMPORT loc 
-  | "option"     , _   -> OPTION
-  | "extensions" , _   -> EXTENSIONS
-  | "extend"     , _   -> EXTEND
-  | "syntax"     , _   -> SYNTAX
-  | "public"     , _   -> PUBLIC
-  | "to"         , _   -> TO
-  | "max"        , _   -> MAX
-  | "map"        , _   -> MAP
-  | "reserved"   , _   -> RESERVED
-  | _ , loc -> IDENT (loc, ident) 
-  (* Note than when updating the list of keywords, 
-   * the [field_name] rule in pbparser.mly should 
-   * also be updated to allow field name of the 
+let resolve_identifier loc ident =
+  match ident, loc with
+  | "message"    , _   -> T_message
+  | "required"   , _   -> T_required
+  | "optional"   , _   -> T_optional
+  | "repeated"   , _   -> T_repeated
+  | "oneof"      , loc -> T_one_of loc
+  | "enum"       , _   -> T_enum
+  | "package"    , _   -> T_package
+  | "import"     , loc -> T_import loc
+  | "option"     , _   -> T_option
+  | "extensions" , _   -> T_extensions
+  | "extend"     , _   -> T_extend
+  | "syntax"     , _   -> T_syntax
+  | "public"     , _   -> T_public
+  | "to"         , _   -> T_to
+  | "max"        , _   -> T_max
+  | "map"        , _   -> T_map
+  | "reserved"   , _   -> T_reserved
+  | _ , loc -> T_ident (loc, ident)
+  (* Note than when updating the list of keywords,
+   * the [field_name] rule in pbparser.mly should
+   * also be updated to allow field name of the
    * keyword.
    *)
 
 type comment =
-  | Comment_value of string  
-  | Comment_eof  
+  | Comment_value of string
+  | Comment_eof
 
-let comment_value s = Comment_value s 
+let comment_value s = Comment_value s
 
 let comment_eof     = Comment_eof
 
-type string_ = 
-  | String_value of string 
+type string_ =
+  | String_value of string
   | String_eof
 
-let string_value s = String_value s 
+let string_value s = String_value s
 
-let string_eof     = String_eof 
+let string_eof     = String_eof
 
 let update_loc lexbuf =
   let pos = lexbuf.Lexing.lex_curr_p in
@@ -80,10 +80,10 @@ let update_loc lexbuf =
 let letter        = ['a'-'z' 'A'-'Z']
 let identchar     = ['A'-'Z' 'a'-'z' '_' '0'-'9']
 let ident         = letter identchar *
-let full_ident    = '.' ? ident ("." * ident) * 
+let full_ident    = '.' ? ident ("." * ident) *
 (* let message_type  = '.' ? (ident '.') ident
  *)
-let int_litteral  = ['+' '-']? ['0'-'9']+ 
+let int_litteral  = ['+' '-']? ['0'-'9']+
 let inf_litteral  = ['+' '-']? "inf"
 
 (* TODO fix: somehow E1 for field identified get lexed into a float.
@@ -97,58 +97,58 @@ let newline  = ('\013'* '\010')
 let blank    = [' ' '\009' '\012']
 
 rule lexer = parse
-  | "{"         { LBRACE }
-  | "}"         { RBRACE }
-  | "["         { LBRACKET}
-  | "]"         { RBRACKET}
-  | ")"         { RPAREN }
-  | "("         { LPAREN }
-  | "<"         { LANGLEB }
-  | ">"         { RANGLEB }
-  | "="         { EQUAL }
-  | ";"         { SEMICOLON }
-  | ","         { COMMA }
-  | "//"        { match comment [] lexbuf with 
-    | Comment_eof     -> EOF 
-    | Comment_value _ -> lexer lexbuf  
+  | "{"         { T_lbrace }
+  | "}"         { T_rbrace }
+  | "["         { T_lbracket}
+  | "]"         { T_rbracket}
+  | ")"         { T_rparen }
+  | "("         { T_lparen }
+  | "<"         { T_less }
+  | ">"         { T_greater }
+  | "="         { T_equal }
+  | ";"         { T_semi }
+  | ","         { T_comma }
+  | "//"        { match comment [] lexbuf with
+    | Comment_eof     -> T_eof
+    | Comment_value _ -> lexer lexbuf
   }
-  | "/*"        { match multi_line_comment [] lexbuf with 
-    | Comment_eof     -> EOF 
-    | Comment_value _ -> lexer lexbuf  
+  | "/*"        { match multi_line_comment [] lexbuf with
+    | Comment_eof     -> T_eof
+    | Comment_value _ -> lexer lexbuf
   }
-  | "\""          { match string [] lexbuf with 
-    | String_eof     -> EOF
-    | String_value s -> STRING s
+  | "\""          { match string [] lexbuf with
+    | String_eof     -> T_eof
+    | String_value s -> T_string s
   }
-  | int_litteral  { INT (int_of_string @@ Lexing.lexeme lexbuf) }
-  | float_literal { FLOAT (float_of_string @@ Lexing.lexeme lexbuf) }
-  | inf_litteral  { FLOAT nan }
+  | int_litteral  { T_int (int_of_string @@ Lexing.lexeme lexbuf) }
+  | float_literal { T_float (float_of_string @@ Lexing.lexeme lexbuf) }
+  | inf_litteral  { T_float nan }
   | newline       { update_loc lexbuf; lexer lexbuf }
   | blank         { lexer lexbuf }
   | full_ident    { resolve_identifier (Loc.from_lexbuf lexbuf) (Lexing.lexeme lexbuf) }
-  | eof           { EOF }
+  | eof           { T_eof }
   | _             { failwith @@ Printf.sprintf "Unknown character found %s" @@
-  Lexing.lexeme lexbuf}  
+  Lexing.lexeme lexbuf}
 
-and comment l = parse 
-  | newline {update_loc lexbuf ; comment_value @@ String.concat "" (List.rev l)} 
-  | _       {comment ((Lexing.lexeme lexbuf)::l) lexbuf }  
-  | eof     {comment_eof } 
+and comment l = parse
+  | newline {update_loc lexbuf ; comment_value @@ String.concat "" (List.rev l)}
+  | _       {comment ((Lexing.lexeme lexbuf)::l) lexbuf }
+  | eof     {comment_eof }
 
-and multi_line_comment l = parse  
+and multi_line_comment l = parse
   | newline {update_loc lexbuf ; multi_line_comment l lexbuf }
   | "*/" {
-      ignore @@ Lexing.lexeme lexbuf; 
+      ignore @@ Lexing.lexeme lexbuf;
       comment_value @@ String.concat "" (List.rev l)
   }
-  | _       {multi_line_comment ((Lexing.lexeme lexbuf)::l) lexbuf }  
-  | eof     { comment_eof } 
+  | _       {multi_line_comment ((Lexing.lexeme lexbuf)::l) lexbuf }
+  | eof     { comment_eof }
 
-and string l = parse 
-  | '\\' ['\\' '\'' '"' 'n' 't' 'b' 'r' ' '] { 
-    let c = Lexing.lexeme_char lexbuf 1 in 
-    string ((Char.escaped c)::l) lexbuf 
+and string l = parse
+  | '\\' ['\\' '\'' '"' 'n' 't' 'b' 'r' ' '] {
+    let c = Lexing.lexeme_char lexbuf 1 in
+    string ((Char.escaped c)::l) lexbuf
   }
-  | "\""    {string_value  @@ String.concat "" (List.rev l)} 
-  | _       {string ((Lexing.lexeme lexbuf)::l) lexbuf }  
-  | eof     {string_eof} 
+  | "\""    {string_value  @@ String.concat "" (List.rev l)}
+  | _       {string ((Lexing.lexeme lexbuf)::l) lexbuf }
+  | eof     {string_eof}

--- a/src/compilerlib/pb_parsing_parser.mly
+++ b/src/compilerlib/pb_parsing_parser.mly
@@ -1,8 +1,8 @@
 /*(*
   The MIT License (MIT)
-  
+
   Copyright (c) 2016 Maxime Ransan <maxime.ransan@gmail.com>
-  
+
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights
@@ -14,118 +14,101 @@
   copies or substantial portions of the Software.
 
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  IMPLIED, INCLUDING BUT NOT LIMITED T_to THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, T_toRT OR OTHERWISE, ARISING FROM,
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
   *)
 
 */
 
-%token REQUIRED
-%token OPTIONAL
-%token REPEATED
+/*Tokens*/
 
-%token <Pb_location.t> ONE_OF
+%token T_required
+%token T_optional
+%token T_repeated
+%token <Pb_location.t> T_one_of
+%token T_message
+%token T_enum
+%token T_package
+%token <Pb_location.t> T_import
+%token T_public
+%token T_option
+%token T_extensions
+%token T_extend
+%token T_reserved
+%token T_syntax
+%token T_to
+%token T_max
+%token T_map
+%token T_rbrace
+%token T_lbrace
+%token T_rbracket
+%token T_lbracket
+%token T_rparen
+%token T_lparen
+%token T_greater
+%token T_less
+%token T_equal
+%token T_semi
+%token T_comma
+%token <string> T_string
+%token <int>    T_int
+%token <float>  T_float
+%token <Pb_location.t * string> T_ident
+%token T_eof
 
-%token MESSAGE
-
-%token ENUM 
-
-%token PACKAGE
-
-%token <Pb_location.t> IMPORT
-%token PUBLIC
-
-%token OPTION
-
-%token EXTENSIONS
-
-%token EXTEND
-
-%token RESERVED
-
-%token SYNTAX 
-
-%token TO
-%token MAX
-
-%token MAP
-
-%token RBRACE
-%token LBRACE
-%token RBRACKET
-%token LBRACKET 
-%token RPAREN  
-%token LPAREN
-%token RANGLEB  
-%token LANGLEB
-%token EQUAL
-%token SEMICOLON
-%token COMMA
-%token <string> STRING 
-%token <int>    INT
-%token <float>  FLOAT
-%token <Pb_location.t * string> IDENT
-%token EOF
+/*Entry points*/
 
 %start field_options_
 %type <Pb_option.set> field_options_
-
-%start normal_field_ 
+%start normal_field_
 %type <Pb_parsing_parse_tree.message_field> normal_field_
-
-%start enum_value_ 
+%start enum_value_
 %type <Pb_parsing_parse_tree.enum_body_content> enum_value_
-
 %start enum_
 %type <Pb_parsing_parse_tree.enum> enum_
-
 %start oneof_
 %type <Pb_parsing_parse_tree.oneof> oneof_
-
 %start message_
 %type <Pb_parsing_parse_tree.message> message_
-
-%start proto_ 
+%start proto_
 %type <Pb_parsing_parse_tree.proto> proto_
-
-%start import_ 
+%start import_
 %type <Pb_parsing_parse_tree.import> import_
-
 %start option_
 %type <Pb_option.t> option_
-
-%start extension_range_list_ 
-%type <Pb_parsing_parse_tree.extension_range list> extension_range_list_ 
-
+%start extension_range_list_
+%type <Pb_parsing_parse_tree.extension_range list> extension_range_list_
 %start extension_
 %type <Pb_parsing_parse_tree.extension_range list> extension_
-
 %start reserved_
 %type <Pb_parsing_parse_tree.extension_range list> reserved_
 
 %%
 
-/*(* The following symbol are for internal testing only *) */ 
+/*Rules*/
 
-field_options_   : field_options EOF {$1}  
-normal_field_    : normal_field  EOF {$1}
-enum_value_      : enum_value    EOF {$1}
-enum_            : enum          EOF {$1}
-oneof_           : oneof         EOF {$1} 
-message_         : message       EOF {$1} 
-import_          : import        EOF {$1} 
-option_          : option        EOF {$1} 
-extension_range_list_ : extension_range_list EOF {$1}
-extension_       : extension     EOF {$1}
-reserved_        : reserved      EOF {$1}
+
+/*(* The following symbol are for internal testing only *) */
+
+field_options_   : field_options T_eof {$1}
+normal_field_    : normal_field  T_eof {$1}
+enum_value_      : enum_value    T_eof {$1}
+enum_            : enum          T_eof {$1}
+oneof_           : oneof         T_eof {$1}
+message_         : message       T_eof {$1}
+import_          : import        T_eof {$1}
+option_          : option        T_eof {$1}
+extension_range_list_ : extension_range_list T_eof {$1}
+extension_       : extension     T_eof {$1}
+reserved_        : reserved      T_eof {$1}
 
 /* (* Main protobuf symbol *) */
 
-proto_           : proto         EOF {$1} 
+proto_           : proto         T_eof {$1}
 
 proto:
   | syntax proto_content {Pb_parsing_util.proto ~syntax:$1 ~proto:$2 ()}
@@ -147,23 +130,23 @@ proto_content:
   | extend              proto {Pb_parsing_util.proto ~extend:$1 ~proto:$2 ()}
 
 syntax:
-  | SYNTAX EQUAL STRING semicolon { $3 }
+  | T_syntax T_equal T_string semicolon { $3 }
 
 import:
-  | IMPORT STRING semicolon         { Pb_parsing_util.import $2} 
-  | IMPORT PUBLIC STRING semicolon  { Pb_parsing_util.import ~public:() $3 }
-  | IMPORT IDENT STRING semicolon   { Pb_exception.invalid_import_qualifier $1 } /*HT*/ 
+  | T_import T_string semicolon         { Pb_parsing_util.import $2}
+  | T_import T_public T_string semicolon  { Pb_parsing_util.import ~public:() $3 }
+  | T_import T_ident T_string semicolon   { Pb_exception.invalid_import_qualifier $1 } /*HT*/
 
 package_declaration :
-  | PACKAGE IDENT semicolon {snd $2}  
+  | T_package T_ident semicolon {snd $2}
 
-message : 
-  | MESSAGE IDENT LBRACE message_body_content_list rbrace { 
+message :
+  | T_message T_ident T_lbrace message_body_content_list rbrace {
     Pb_parsing_util.message ~content:$4 (snd $2)
-  } 
-  | MESSAGE IDENT LBRACE rbrace { 
+  }
+  | T_message T_ident T_lbrace rbrace {
     Pb_parsing_util.message ~content:[]  (snd $2)
-  } 
+  }
 
 message_body_content_list:
   | message_body_content  { [$1] }
@@ -179,145 +162,145 @@ message_body_content :
   | reserved     { Pb_parsing_util.message_body_reserved $1 }
   | option       { Pb_parsing_util.message_body_option $1 }
 
-extend : 
-  | EXTEND IDENT LBRACE normal_field_list rbrace {
-    Pb_parsing_util.extend (snd $2) $4 
+extend :
+  | T_extend T_ident T_lbrace normal_field_list rbrace {
+    Pb_parsing_util.extend (snd $2) $4
   }
-  | EXTEND IDENT LBRACE rbrace {
-    Pb_parsing_util.extend (snd $2) [] 
+  | T_extend T_ident T_lbrace rbrace {
+    Pb_parsing_util.extend (snd $2) []
   }
 
 normal_field_list :
   | normal_field                   {$1 :: []}
   | normal_field normal_field_list {$1 :: $2}
 
-extension : 
-  | EXTENSIONS extension_range_list semicolon {$2}  
+extension :
+  | T_extensions extension_range_list semicolon {$2}
 
-reserved : 
-  | RESERVED extension_range_list semicolon {$2}
-/* TODO: incomplete, reserved field can also be defined by field names */
+reserved :
+  | T_reserved extension_range_list semicolon {$2}
+/* T_toDO: incomplete, reserved field can also be defined by field names */
 
-extension_range_list : 
+extension_range_list :
   | extension_range                            {$1 :: []}
-  | extension_range COMMA extension_range_list {$1 :: $3} 
+  | extension_range T_comma extension_range_list {$1 :: $3}
 
 extension_range :
-  | INT            { Pb_parsing_util.extension_range_single_number $1} 
-  | INT TO INT     { Pb_parsing_util.extension_range_range $1 (`Number $3) } 
-  | INT TO MAX     { Pb_parsing_util.extension_range_range $1 `Max } 
+  | T_int            { Pb_parsing_util.extension_range_single_number $1}
+  | T_int T_to T_int     { Pb_parsing_util.extension_range_range $1 (`Number $3) }
+  | T_int T_to T_max     { Pb_parsing_util.extension_range_range $1 `Max }
 
 oneof :
-  | ONE_OF IDENT LBRACE oneof_field_list rbrace { 
-    Pb_parsing_util.oneof ~fields:$4 (snd $2) 
-  }  
-  | ONE_OF LBRACE oneof_field_list rbrace { 
+  | T_one_of T_ident T_lbrace oneof_field_list rbrace {
+    Pb_parsing_util.oneof ~fields:$4 (snd $2)
+  }
+  | T_one_of T_lbrace oneof_field_list rbrace {
     Pb_exception.missing_one_of_name $1
-  }  
+  }
 
 oneof_field_list :
   |                                     { []   }
-  | oneof_field oneof_field_list        { $1::$2 } 
+  | oneof_field oneof_field_list        { $1::$2 }
 
-oneof_field : 
-  | IDENT field_name EQUAL INT field_options semicolon { 
-    Pb_parsing_util.oneof_field ~type_:(snd $1) ~number:$4 ~options:$5 $2  
-  } 
-  | IDENT field_name EQUAL INT semicolon { 
-    Pb_parsing_util.oneof_field ~type_:(snd $1) ~number:$4 $2  
-  } 
+oneof_field :
+  | T_ident field_name T_equal T_int field_options semicolon {
+    Pb_parsing_util.oneof_field ~type_:(snd $1) ~number:$4 ~options:$5 $2
+  }
+  | T_ident field_name T_equal T_int semicolon {
+    Pb_parsing_util.oneof_field ~type_:(snd $1) ~number:$4 $2
+  }
 
 map :
-  | MAP LANGLEB IDENT COMMA IDENT RANGLEB field_name EQUAL INT semicolon {
-    Pb_parsing_util.map_field 
+  | T_map T_less T_ident T_comma T_ident T_greater field_name T_equal T_int semicolon {
+    Pb_parsing_util.map_field
         ~key_type:(snd $3) ~value_type:(snd $5) ~number:$9 $7
   }
-  | MAP LANGLEB IDENT COMMA IDENT RANGLEB field_name EQUAL INT field_options semicolon {
-    Pb_parsing_util.map_field 
+  | T_map T_less T_ident T_comma T_ident T_greater field_name T_equal T_int field_options semicolon {
+    Pb_parsing_util.map_field
         ~options:$10 ~key_type:(snd $3) ~value_type:(snd $5) ~number:$9 $7
   }
 
-normal_field : 
-  | label IDENT field_name EQUAL INT field_options semicolon { 
+normal_field :
+  | label T_ident field_name T_equal T_int field_options semicolon {
     Pb_parsing_util.field ~label:$1 ~type_:(snd $2) ~number:$5 ~options:$6 $3
-  } 
-  | label IDENT field_name EQUAL INT semicolon { 
-    Pb_parsing_util.field ~label:$1 ~type_:(snd $2) ~number:$5 $3 
-  } 
-  | IDENT field_name EQUAL INT field_options semicolon { 
-    Pb_parsing_util.field 
+  }
+  | label T_ident field_name T_equal T_int semicolon {
+    Pb_parsing_util.field ~label:$1 ~type_:(snd $2) ~number:$5 $3
+  }
+  | T_ident field_name T_equal T_int field_options semicolon {
+    Pb_parsing_util.field
         ~label:`Nolabel ~type_:(snd $1) ~number:$4 ~options:$5 $2
   }
-  | IDENT field_name EQUAL INT semicolon { 
+  | T_ident field_name T_equal T_int semicolon {
     Pb_parsing_util.field ~label:`Nolabel ~type_:(snd $1) ~number:$4 $2
   }
 
 field_name :
-  | IDENT     {snd $1}
-  | REQUIRED  {"required"}
-  | OPTIONAL  {"optional"}
-  | REPEATED  {"repeated"}
-  | ONE_OF    {"oneof"}
-  | ENUM      {"enum"}
-  | PACKAGE   {"package"}
-  | IMPORT    {"import"}
-  | PUBLIC    {"public"}
-  | OPTION    {"option"}
-  | EXTENSIONS{"extensions"}
-  | EXTEND    {"extend"}
-  | RESERVED  {"reserved"}
-  | SYNTAX    {"syntax"}
-  | MESSAGE   {"message"}
-  | TO        {"to"}
-  | MAX       {"max"}
-  | MAP       {"map"}
+  | T_ident     {snd $1}
+  | T_required  {"required"}
+  | T_optional  {"optional"}
+  | T_repeated  {"repeated"}
+  | T_one_of    {"oneof"}
+  | T_enum      {"enum"}
+  | T_package   {"package"}
+  | T_import    {"import"}
+  | T_public    {"public"}
+  | T_option    {"option"}
+  | T_extensions{"extensions"}
+  | T_extend    {"extend"}
+  | T_reserved  {"reserved"}
+  | T_syntax    {"syntax"}
+  | T_message   {"message"}
+  | T_to        {"to"}
+  | T_max       {"max"}
+  | T_map       {"map"}
 
 label :
-  | REQUIRED { `Required }  
-  | REPEATED { `Repeated }
-  | OPTIONAL { `Optional }
+  | T_required { `Required }
+  | T_repeated { `Repeated }
+  | T_optional { `Optional }
 
-field_options : 
-  | LBRACKET field_option_list RBRACKET { $2 }; 
-  | LBRACKET RBRACKET                   { Pb_option.empty }; 
+field_options :
+  | T_lbracket field_option_list T_rbracket { $2 };
+  | T_lbracket T_rbracket                   { Pb_option.empty };
 
-field_option_list : 
-  | field_option                          { 
-    let option_name, option_value = $1 in 
-    Pb_option.add Pb_option.empty option_name option_value 
-  } 
-  | field_option COMMA field_option_list  { 
+field_option_list :
+  | field_option                          {
+    let option_name, option_value = $1 in
+    Pb_option.add Pb_option.empty option_name option_value
+  }
+  | field_option T_comma field_option_list  {
     Pb_option.add $3 (fst $1) (snd $1)
   }
 
 field_option :
-  | IDENT EQUAL constant               { (snd $1, $3) } 
-  | LPAREN IDENT RPAREN EQUAL constant { (snd $2, $5)} 
+  | T_ident T_equal constant               { (snd $1, $3) }
+  | T_lparen T_ident T_rparen T_equal constant { (snd $2, $5)}
 
 option_identifier_item :
-  | IDENT                   {snd $1}
-  | LPAREN IDENT RPAREN     {snd $2}
+  | T_ident                   {snd $1}
+  | T_lparen T_ident T_rparen     {snd $2}
 
-option_identifier : 
+option_identifier :
   | option_identifier_item    {$1}
-  | option_identifier IDENT   {$1 ^ (snd $2)}
+  | option_identifier T_ident   {$1 ^ (snd $2)}
 
 option :
-  | OPTION option_identifier EQUAL constant semicolon { ($2, $4) }
+  | T_option option_identifier T_equal constant semicolon { ($2, $4) }
 
-constant : 
-  | INT        { Pb_option.Constant_int $1 }
-  | FLOAT      { Pb_option.Constant_float $1 }
-  | IDENT      { 
-    match (snd $1) with 
-    | "true"   -> Pb_option.Constant_bool true 
-    | "false"  -> Pb_option.Constant_bool false 
-    | litteral -> Pb_option.Constant_litteral litteral 
+constant :
+  | T_int        { Pb_option.Constant_int $1 }
+  | T_float      { Pb_option.Constant_float $1 }
+  | T_ident      {
+    match (snd $1) with
+    | "true"   -> Pb_option.Constant_bool true
+    | "false"  -> Pb_option.Constant_bool false
+    | litteral -> Pb_option.Constant_litteral litteral
   }
-  | STRING     { Pb_option.Constant_string $1 }; 
+  | T_string     { Pb_option.Constant_string $1 };
 
 enum:
-  | ENUM IDENT LBRACE enum_values rbrace { Pb_parsing_util.enum ~enum_body:$4 (snd $2) } 
+  | T_enum T_ident T_lbrace enum_values rbrace { Pb_parsing_util.enum ~enum_body:$4 (snd $2) }
 
 enum_values:
   |                                { [] }
@@ -327,21 +310,21 @@ enum_body_content :
   | option     { Pb_parsing_util.enum_option $1 }
   | enum_value { $1 }
 
-enum_value : 
-  | IDENT EQUAL INT semicolon  { Pb_parsing_util.enum_value ~int_value:$3 (snd $1) } 
-  | IDENT EQUAL INT { 
-    Pb_exception.missing_semicolon_for_enum_value (snd $1) (fst $1) 
+enum_value :
+  | T_ident T_equal T_int semicolon  { Pb_parsing_util.enum_value ~int_value:$3 (snd $1) }
+  | T_ident T_equal T_int {
+    Pb_exception.missing_semicolon_for_enum_value (snd $1) (fst $1)
   }
-  | IDENT EQUAL INT COMMA { Pb_exception.invalid_enum_specification (snd $1) (fst $1)}
-  | IDENT COMMA           { Pb_exception.invalid_enum_specification (snd $1) (fst $1)}
-  | IDENT SEMICOLON       { Pb_exception.invalid_enum_specification (snd $1) (fst $1)}
-  | IDENT                 { Pb_exception.invalid_enum_specification (snd $1) (fst $1)}
+  | T_ident T_equal T_int T_comma { Pb_exception.invalid_enum_specification (snd $1) (fst $1)}
+  | T_ident T_comma           { Pb_exception.invalid_enum_specification (snd $1) (fst $1)}
+  | T_ident T_semi       { Pb_exception.invalid_enum_specification (snd $1) (fst $1)}
+  | T_ident                 { Pb_exception.invalid_enum_specification (snd $1) (fst $1)}
 
 semicolon:
-  | SEMICOLON           {()} 
-  | semicolon SEMICOLON {()} 
+  | T_semi           {()}
+  | semicolon T_semi {()}
 
 rbrace :
-  | RBRACE           { () }
-  | rbrace SEMICOLON { () }
+  | T_rbrace           { () }
+  | rbrace T_semi { () }
 %%


### PR DESCRIPTION
Also, delete trailing whitespace in the lexer and parser.