### PR TITLE
Fix read_file for CRLF line ending (Windows)

### DIFF
--- a/src/compilerlib/pb_util.ml
+++ b/src/compilerlib/pb_util.ml
@@ -88,13 +88,13 @@ let read_file file_name =
   let b = Bytes.create len in 
   let offset = ref 0 in 
   let remaining = ref len in 
-  while !offset <> len do 
+  while !remaining > 0 do
     let i = input ic b !offset ! remaining in 
     offset:=(!offset + i); 
-    remaining:=(!remaining - i);
+    remaining:=(if i > 0 then !remaining - i else 0);
   done; 
   close_in ic;
-  Bytes.to_string b 
+  Bytes.sub_string b 0 !offset
 
 module List = struct 
   let rec pop_last = function 


### PR DESCRIPTION
From `in_channel_length` docs:
> Return the size (number of characters) of the regular file on which the given channel is opened.  If the channel is opened on a file that is not a regular file, the result is meaningless. **The returned size does not take into account the end-of-line translations** that can be performed when reading from a channel opened in text mode.

Due to that `read_file` goes stuck in infinite loop under Windows. This PR hopefully fixes that.