### PR TITLE
Fix typo in mapping documentation

### DIFF
--- a/doc/protobuf_ocaml_mapping.md
+++ b/doc/protobuf_ocaml_mapping.md
@@ -57,7 +57,7 @@ functions are generated.*
 
 ##### [Message](https://developers.google.com/protocol-buffers/docs/proto#simple) 
 
-Message are compiled to OCaml `records` with all fields mutable, while `oneof` fields are compiled to OCaml variant.
+Message are compiled to OCaml `records` with all fields immutable, while `oneof` fields are compiled to OCaml variant.
 
 **Oneof optimization**
 


### PR DESCRIPTION
Took me a few minutes to realize that the options page was correct and this one had the typo. ;)