### PR TITLE
Add ability to parse stream modifier

### DIFF
--- a/src/compilerlib/pb_parsing_lexer.mll
+++ b/src/compilerlib/pb_parsing_lexer.mll
@@ -43,6 +43,7 @@ let resolve_identifier loc ident =
   | "returns"    , _   -> T_returns
   | "rpc"        , _   -> T_rpc
   | "service"    , _   -> T_service
+  | "stream"     , _   -> T_stream
   | "syntax"     , _   -> T_syntax
   | "public"     , _   -> T_public
   | "to"         , _   -> T_to

--- a/src/compilerlib/pb_parsing_parse_tree.ml
+++ b/src/compilerlib/pb_parsing_parse_tree.ml
@@ -126,7 +126,9 @@ and message = {
 type rpc = {
   rpc_name: string;
   rpc_options: Pb_option.set;
+  rpc_req_stream: bool;
   rpc_req: Pb_field_type.unresolved_t;
+  rpc_res_stream: bool;
   rpc_res: Pb_field_type.unresolved_t;
 }
 

--- a/src/compilerlib/pb_parsing_parser.mly
+++ b/src/compilerlib/pb_parsing_parser.mly
@@ -42,6 +42,7 @@
 %token T_returns
 %token T_rpc
 %token T_service
+%token T_stream
 %token T_syntax
 %token T_to
 %token T_max
@@ -206,12 +207,16 @@ service_body_content :
   | rpc          { Pb_parsing_util.service_body_rpc $1 }
   | option       { Pb_parsing_util.service_body_option $1 }
 
+message_type :
+  | T_stream T_ident { (true, snd $2) }
+  | T_ident { (false, snd $1) }
+
 rpc :
-  | T_rpc T_ident T_lparen T_ident T_rparen T_returns T_lparen T_ident T_rparen semicolon {
-    Pb_parsing_util.rpc ~req:(snd $4) ~res:(snd $8) (snd $2)
+  | T_rpc T_ident T_lparen message_type T_rparen T_returns T_lparen message_type T_rparen semicolon {
+    Pb_parsing_util.rpc ~req_stream:(fst $4) ~req:(snd $4) ~res_stream:(fst $8) ~res:(snd $8) (snd $2)
   }
-  | T_rpc T_ident T_lparen T_ident T_rparen T_returns T_lparen T_ident T_rparen rpc_options {
-    Pb_parsing_util.rpc ~req:(snd $4) ~res:(snd $8) ~options:$10 (snd $2)
+  | T_rpc T_ident T_lparen message_type T_rparen T_returns T_lparen message_type T_rparen rpc_options {
+    Pb_parsing_util.rpc ~req_stream:(fst $4) ~req:(snd $4) ~res_stream:(fst $8) ~res:(snd $8) ~options:$10 (snd $2)
   }
 
 rpc_options :

--- a/src/compilerlib/pb_parsing_util.ml
+++ b/src/compilerlib/pb_parsing_util.ml
@@ -129,11 +129,13 @@ let service_body_option option_ = Pt.Service_option option_
 
 let service_body_rpc rpc = Pt.Service_rpc rpc
 
-let rpc ?(options=Pb_option.empty) ~req ~res rpc_name =
+let rpc ?(options=Pb_option.empty) ~req_stream ~req ~res_stream ~res rpc_name =
   Pt.({
       rpc_name;
       rpc_options = options;
+      rpc_req_stream = req_stream;
       rpc_req = Pb_field_type.parse req;
+      rpc_res_stream = res_stream;
       rpc_res = Pb_field_type.parse res;
     })
 

--- a/src/compilerlib/pb_parsing_util.mli
+++ b/src/compilerlib/pb_parsing_util.mli
@@ -46,92 +46,94 @@ val map_field :
   key_type:string ->
   value_type:string ->
   string ->
-  Pt.map_field 
+  Pt.map_field
 
-val oneof_field : 
+val oneof_field :
   ?options:Pb_option.set ->
-  number:int -> 
-  type_:string -> 
-  string -> 
+  number:int ->
+  type_:string ->
+  string ->
   Pt.oneof_field
 
 val oneof :
-  fields:Pt.oneof_field list -> 
-  string -> 
-  Pt.oneof 
+  fields:Pt.oneof_field list ->
+  string ->
+  Pt.oneof
 
-val message_body_field : 
-  Pt.message_field  -> 
-  Pt.message_body_content  
+val message_body_field :
+  Pt.message_field  ->
+  Pt.message_body_content
 
-val message_body_map_field : 
+val message_body_map_field :
   Pt.map_field ->
-  Pt.message_body_content  
+  Pt.message_body_content
 
-val message_body_oneof_field  : 
-  Pt.oneof -> 
-  Pt.message_body_content 
+val message_body_oneof_field  :
+  Pt.oneof ->
+  Pt.message_body_content
 
 val enum_value :
-  int_value:int -> 
-  string -> 
+  int_value:int ->
+  string ->
   Pt.enum_body_content
 
 val enum_option :
-  Pb_option.t -> 
+  Pb_option.t ->
   Pt.enum_body_content
 
-val enum : 
-  ?enum_body:Pt.enum_body_content list -> 
-  string -> 
-  Pt.enum 
+val enum :
+  ?enum_body:Pt.enum_body_content list ->
+  string ->
+  Pt.enum
 
 val extension_range_single_number : int -> Pt.extension_range
 
-val extension_range_range : int -> [ `Max | `Number of int ] -> Pt.extension_range 
+val extension_range_range : int -> [ `Max | `Number of int ] -> Pt.extension_range
 
-val message_body_sub : 
-  Pt.message -> 
+val message_body_sub :
+  Pt.message ->
   Pt.message_body_content
 
-val message_body_enum: 
-  Pt.enum -> 
+val message_body_enum:
+  Pt.enum ->
   Pt.message_body_content
 
-val message_body_extension: 
-  Pt.extension_range list  -> 
+val message_body_extension:
+  Pt.extension_range list  ->
   Pt.message_body_content
 
-val message_body_reserved: 
-  Pt.extension_range list  -> 
+val message_body_reserved:
+  Pt.extension_range list  ->
   Pt.message_body_content
 
-val message_body_option : 
-  Pb_option.t -> 
+val message_body_option :
+  Pb_option.t ->
   Pt.message_body_content
 
-val message : 
-  content:Pt.message_body_content list -> 
-  string -> 
+val message :
+  content:Pt.message_body_content list ->
+  string ->
   Pt.message
 
 val rpc:
   ?options:Pb_option.set ->
+  req_stream:bool ->
   req:string ->
+  res_stream:bool ->
   res:string ->
-  string -> 
+  string ->
   Pt.rpc
 
 val rpc_option_map:
   ((string * string) list) ->
   Pb_option.constant
 
-val service_body_option : 
-  Pb_option.t -> 
+val service_body_option :
+  Pb_option.t ->
   Pt.service_body_content
 
-val service_body_rpc : 
-  Pt.rpc -> 
+val service_body_rpc :
+  Pt.rpc ->
   Pt.service_body_content
 
 val service :


### PR DESCRIPTION
Following on from the great work in https://github.com/mransan/ocaml-protoc/pull/152, this adds support for the stream keyword in rpc definitions.

It doesn't follow through with generating anything with them but allows them to parse and sets up some code for future use.