### PR TITLE
fix services parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ ocaml_protoc.byte
 ocaml_protoc.native
 
 .merlin
+
+*.orig

--- a/src/compilerlib/pb_parsing_parser.mly
+++ b/src/compilerlib/pb_parsing_parser.mly
@@ -326,6 +326,8 @@ field_name :
   | T_reserved  {"reserved"}
   | T_syntax    {"syntax"}
   | T_message   {"message"}
+  | T_service   {"service"}
+  | T_rpc       {"rpc"}
   | T_to        {"to"}
   | T_max       {"max"}
   | T_map       {"map"}


### PR DESCRIPTION
this PR fixes an issue when a field name has the name `service` or `rpc` and adds tests