### PR TITLE
Minor refactor + Encoder.{reset,clear}

### DIFF
--- a/src/compilerlib/pb_codegen_util.ml
+++ b/src/compilerlib/pb_codegen_util.ml
@@ -117,7 +117,7 @@ let camel_case_of_label s =
     else begin
       begin
         if !capitalize
-        then begin Bytes.set b !blen (Char.uppercase c) end
+        then begin Bytes.set b !blen (Char.uppercase_ascii c) end
         else begin Bytes.set b !blen c end;
       end;
       capitalize := false;
@@ -127,7 +127,7 @@ let camel_case_of_label s =
   Bytes.sub_string b 0 !blen
 
 let camel_case_of_constructor s =
-  camel_case_of_label (String.lowercase s)
+  camel_case_of_label (String.lowercase_ascii s)
 
 let collect_modules_of_field_type modules = function
   | Ot.Ft_user_defined_type {Ot.udt_module_prefix = Some m; _} ->

--- a/src/runtime/pbrt.ml
+++ b/src/runtime/pbrt.ml
@@ -376,6 +376,9 @@ module Encoder = struct
   let create () =
     Buffer.create 16
 
+  let clear = Buffer.clear
+  let reset = Buffer.reset
+
   let to_string = Buffer.contents
 
   let to_bytes = Buffer.to_bytes

--- a/src/runtime/pbrt.mli
+++ b/src/runtime/pbrt.mli
@@ -225,6 +225,16 @@ module Encoder : sig
 
   val create : unit -> t
 
+  val clear : t -> unit
+  (** Clear the content of the internal buffer(s), but does not release memory
+      @since 2.1 *)
+
+  val reset : t -> unit
+  (** Clears the content and resets internal storage
+      to its initial memory consumption. This is more costly than {!clear} but
+      can be useful after a very large message was encoded.
+      @since 2.1 *)
+
   (** {2 Convertion} *)
 
   val to_bytes : t -> bytes


### PR DESCRIPTION
I'm also considering storing multiple buffers in `Encoder.t` for nested values, so that at most n buffers are allocated, where n = the maximum nesting depth, rather than n = total number of nested values. Would that be useful to the project?