### PR TITLE
rename runtime library into `pbrt`, make it independent

### DIFF
--- a/benchs/benchs.ml
+++ b/benchs/benchs.ml
@@ -577,7 +577,7 @@ module Nested = struct
         done
          *)
 
-      let[@inline] int64_as_varint = varint
+      let int64_as_varint = varint
       let int_as_varint i e =
         (varint[@inlined]) (Int64.of_int i) e
 

--- a/dune
+++ b/dune
@@ -1,4 +1,4 @@
 (env
  (_
-   (flags -bin-annot -annot -safe-string 
-          -keep-locs -no-alias-deps -w A-4-42-41-48)))
+   (flags -bin-annot -annot -safe-string -strict-sequence
+          -keep-locs -no-alias-deps -w A-4-42-41-48-70)))

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 1.11)
+(lang dune 2.9)
 (name ocaml-protoc)
 (allow_approximate_merlin)

--- a/pbrt.opam
+++ b/pbrt.opam
@@ -1,11 +1,14 @@
 opam-version: "2.0"
-name: "ocaml-protoc"
+name: "pbrt"
 version: "2.1"
-synopsis: "Protobuf compiler for OCaml"
-description: "Protobuf compiler for OCaml"
+synopsis: "Runtime library for Protobuf tooling"
+description: "Runtime library for Protobuf tooling"
 maintainer: "Maxime Ransan <maxime.ransan@gmail.com>"
 post-messages: [
-"The runtime library is now called \"pbrt\"."
+"Pbrt: runtime library for ocaml-protoc.
+
+A shim library named \"ocaml-protoc\" still exists, to ease the
+migration."
 ]
 authors:[
   "Maxime Ransan <maxime.ransan@gmail.com>"
@@ -24,6 +27,5 @@ depends: [
   "ocaml" {>="4.03.0"}
   "dune"  {>="1.11"}
   "stdlib-shims"
-  "pbrt" {= version}
   "odoc" {with-doc}
 ]

--- a/src/ocaml-protoc/dune
+++ b/src/ocaml-protoc/dune
@@ -1,10 +1,19 @@
-(executable 
+(executable
   (name ocaml_protoc)
   (public_name ocaml-protoc)
-  (modules 
+  (package ocaml-protoc)
+  (modules
     ocaml_protoc
     ocaml_protoc_cmdline
-    ocaml_protoc_compilation 
-    ocaml_protoc_generation) 
+    ocaml_protoc_compilation
+    ocaml_protoc_generation)
   (libraries compiler_lib)
 )
+
+(library
+  (synopsis "Shim to depend on pbrt")
+  (name ocaml_protoc)
+  (public_name ocaml-protoc)
+  (modules)
+  ; (re_export pbrt) ; this seems to require dune 3.0
+  (libraries pbrt))

--- a/src/runtime/dune
+++ b/src/runtime/dune
@@ -1,8 +1,6 @@
 (library
  (name pbrt)
- (public_name ocaml-protoc)
+ (public_name pbrt)
  ; we need to increase -inline, so that the varint encoder/decoder can
  ; be remembered by the inliner.
- (ocamlopt_flags :standard -inline 100)
- (wrapped false)
-)
+ (ocamlopt_flags :standard -inline 100))


### PR DESCRIPTION
related: #173, #144 (going the other way around :))
long term goal: https://github.com/ocaml-ppx/ppx_deriving_protobuf/issues/41