### PR TITLE
Add support for bytes in JSON encoding

### DIFF
--- a/src/compilerlib/pb_codegen_encode_yojson.ml
+++ b/src/compilerlib/pb_codegen_encode_yojson.ml
@@ -30,7 +30,7 @@ let runtime_function_for_basic_type json_label basic_type pk =
   (* bool *)
   | Ot.Bt_bool, Ot.Pk_varint _ -> "make_bool", None
   (* bytes *)
-  | Ot.Bt_bytes, Ot.Pk_bytes -> unsupported json_label
+  | Ot.Bt_bytes, Ot.Pk_bytes -> "make_bytes", None
   | _ -> unsupported json_label
 
 (* TODO Wrapper: add a runtime_function_for_wrapper_type  which will


### PR DESCRIPTION
Tested with:
https://github.com/etcd-io/etcd/blob/main/api/mvccpb/kv.proto https://github.com/etcd-io/etcd/blob/main/api/etcdserverpb/rpc.proto

This depends on a newer ocaml-protoc-yojson that supports bytes, encoded as base64: https://github.com/mransan/ocaml-protoc-yojson/pull/3