### PR TITLE
JSON runtime support for empty messages

### DIFF
--- a/src/runtime-yojson/pbrt_yojson.ml
+++ b/src/runtime-yojson/pbrt_yojson.ml
@@ -72,6 +72,11 @@ let bool v record_name field_name =
 let bytes v record_name field_name =
   string v record_name field_name |> Base64.decode_exn |> Bytes.of_string
 
+let unit v record_name field_name =
+  match v with
+  | `Assoc [] -> ()
+  | _ -> E.unexpected_json_type record_name field_name
+
 let make_bool v = `Bool v
 let make_int v = `Int v
 let make_float v = `Float v
@@ -80,4 +85,5 @@ let make_string v = `String v
 let make_bytes s =
   make_string (s |> Bytes.to_string |> Base64.encode_exn ~pad:true)
 
+let make_unit () = `Assoc []
 let make_list v = `List v

--- a/src/runtime-yojson/pbrt_yojson.mli
+++ b/src/runtime-yojson/pbrt_yojson.mli
@@ -29,9 +29,11 @@ val int64 : Yojson.Basic.t -> string -> string -> int64
 val int : Yojson.Basic.t -> string -> string -> int
 val bool : Yojson.Basic.t -> string -> string -> bool
 val bytes : Yojson.Basic.t -> string -> string -> bytes
+val unit : Yojson.Basic.t -> string -> string -> unit
 val make_bool : bool -> Yojson.Basic.t
 val make_int : int -> Yojson.Basic.t
 val make_float : float -> Yojson.Basic.t
 val make_string : string -> Yojson.Basic.t
 val make_bytes : bytes -> Yojson.Basic.t
+val make_unit : unit -> Yojson.Basic.t
 val make_list : Yojson.Basic.t list -> Yojson.Basic.t


### PR DESCRIPTION
After empty messages support got merged, these helpers were missing in JSON runtime. As it now lives in the same repo - opening PR to address this here.