### PR TITLE
encode backward and use C stubs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
 jobs:
   run:
     name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ ocaml_protoc.native
 *.orig
 _opam
 *.data
+*.exe

--- a/b_run.sh
+++ b/b_run.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec dune exec --profile=release -- benchs/bin/run.exe $@

--- a/benchs/benchs.ml
+++ b/benchs/benchs.ml
@@ -493,7 +493,7 @@ module Varint_size = struct
 
   module C_while = struct
     external varint_size : (int64[@unboxed]) -> int
-      = "caml_pbrt_varint_size_byte" "caml_pbrt_varint_size"
+      = "b_caml_pbrt_varint_size_byte" "b_caml_pbrt_varint_size"
       [@@noalloc]
 
     let loop ~n =
@@ -1062,7 +1062,7 @@ module Nested = struct
 
     (*
     external varint_size : (int64[@unboxed]) -> int
-      = "caml_pbrt_varint_size_byte" "caml_pbrt_varint_size"
+      = "b_caml_pbrt_varint_size_byte" "b_caml_pbrt_varint_size"
       [@@noalloc]
       *)
 
@@ -1083,7 +1083,7 @@ module Nested = struct
 
     external varint_slice :
       bytes -> (int[@untagged]) -> (int64[@unboxed]) -> unit
-      = "caml_pbrt_varint_byte" "caml_pbrt_varint"
+      = "b_caml_pbrt_varint_byte" "b_caml_pbrt_varint"
       [@@noalloc]
 
     let[@inline] varint (i : int64) (e : t) : unit =

--- a/benchs/benchs.ml
+++ b/benchs/benchs.ml
@@ -182,7 +182,7 @@ module Dec = struct
   (* make a buffer with the integers from [0] to [n] inside *)
   let mk_buf_n n : string =
     let enc = Pbrt.Encoder.create () in
-    for i = 0 to n do
+    for i = n downto 0 do
       Pbrt.Encoder.int_as_varint i enc
     done;
     Pbrt.Encoder.to_string enc
@@ -270,7 +270,7 @@ module Dec_bits64 = struct
   (* put the int64 integers from 0 to n in a dec *)
   let mk_buf_n n : string =
     let enc = Pbrt.Encoder.create () in
-    for i = 0 to n do
+    for i = n downto 0 do
       Pbrt.Encoder.int_as_bits64 i enc
     done;
     Pbrt.Encoder.to_string enc

--- a/benchs/benchs.ml
+++ b/benchs/benchs.ml
@@ -664,8 +664,11 @@ module Nested = struct
 
   module Make_bench_of_mk_company (E : MK_COMPANY) = struct
     let bench company =
-      mk_t E.name_of_enc @@ fun () ->
+      (* create an encoder that we'll reuse every time, so we can measure
+         the allocations caused purely by the encoding itself *)
       let enc = E.create () in
+      mk_t E.name_of_enc @@ fun () ->
+      E.clear enc;
       Sys.opaque_identity (E.enc_company company enc)
 
     let string_of_company c =

--- a/benchs/benchs.ml
+++ b/benchs/benchs.ml
@@ -665,14 +665,8 @@ module Nested = struct
   module Make_bench_of_mk_company (E : MK_COMPANY) = struct
     let bench company =
       mk_t E.name_of_enc @@ fun () ->
-      for _i = 1 to 10 do
-        let enc = E.create () in
-        for _j = 1 to 10 do
-          Sys.opaque_identity
-            (E.clear enc;
-             E.enc_company company enc)
-        done
-      done
+      let enc = E.create () in
+      Sys.opaque_identity (E.enc_company company enc)
 
     let string_of_company c =
       let e = E.create () in
@@ -1171,7 +1165,7 @@ module Nested = struct
   let pp_size ~n ~depth =
     Printf.printf "bench nested enc: length for n=%d, depth=%d is %d B\n" n
       depth
-      (String.length (Basic.string_of_company @@ mk_company ~n ~depth))
+      (String.length (Cur.string_of_company @@ mk_company ~n ~depth))
 
   (* sanity check *)
   let check ~n ~depth () =
@@ -1224,7 +1218,7 @@ module Nested = struct
   let () =
     List.iter
       (fun (n, depth) -> check ~n ~depth ())
-      [ 1, 3; 2, 4; 10, 1; 20, 2 ]
+      [ 1, 3; 2, 4; 10, 1; 20, 2; 1, 10 ]
 end
 
 let test_nested_enc ~n ~depth =

--- a/benchs/bin/dune
+++ b/benchs/bin/dune
@@ -1,0 +1,11 @@
+
+(executable
+ (name run)
+ (ocamlopt_flags :standard -inline 100)
+ (libraries pbrt))
+
+(rule
+ (targets foo.ml foo.mli)
+ (deps foo.proto)
+ (action
+  (run ocaml-protoc %{deps} --binary --pp --ml_out .)))

--- a/benchs/bin/foo.proto
+++ b/benchs/bin/foo.proto
@@ -1,0 +1,19 @@
+
+syntax = "proto3";
+
+message Person {
+  string name = 1;
+  sint64 age = 2;
+}
+
+message Store {
+  string address = 1;
+  repeated Person employees = 2;
+  repeated Person clients = 3;
+}
+
+message Company {
+  string name = 1;
+  repeated Store stores = 2;
+  repeated Company subsidiaries = 3;
+}

--- a/benchs/bin/run.ml
+++ b/benchs/bin/run.ml
@@ -1,0 +1,64 @@
+open Foo
+
+let spf = Printf.sprintf
+
+(* company, with [n] stores and [2^depth] subsidiaries *)
+let rec mk_company ~n ~depth : company =
+  {
+    name = "bigcorp";
+    subsidiaries =
+      (if depth = 0 then
+        []
+      else (
+        let c = mk_company ~n ~depth:(depth - 1) in
+        [ c; c ]
+      ));
+    stores =
+      List.init n (fun i ->
+          {
+            address = spf "%d foobar street" i;
+            clients =
+              List.init 2 (fun j ->
+                  {
+                    name = spf "client_%d_%d" i j;
+                    age = Int64.of_int ((j mod 30) + 15);
+                  });
+            employees =
+              List.init 2 (fun j ->
+                  {
+                    name = spf "employee_%d_%d" i j;
+                    age = Int64.of_int ((j mod 30) + 18);
+                  });
+          });
+  }
+
+let comp = mk_company ~n:3 ~depth:2
+
+let () =
+  let n = ref 3 in
+  let depth = ref 2 in
+  let iters = ref 100 in
+
+  let opts =
+    [
+      "-n", Arg.Set_int n, " size for data";
+      "--depth", Arg.Set_int depth, " nesting depth for data";
+      "--iters", Arg.Set_int iters, " number of iterations";
+    ]
+    |> Arg.align
+  in
+  Arg.parse opts ignore "";
+
+  Printf.printf "n=%d, depth=%d, iters=%n\n%!" !n !depth !iters;
+  let comp = mk_company ~n:!n ~depth:!depth in
+
+  let enc = Pbrt.Encoder.create () in
+
+  Sys.opaque_identity (Foo.encode_pb_company comp enc);
+  let size = String.length @@ Pbrt.Encoder.to_string enc in
+  Printf.printf "size=%d B\n%!" size;
+
+  for _i = 1 to !iters do
+    Pbrt.Encoder.clear enc;
+    Sys.opaque_identity (Foo.encode_pb_company comp enc)
+  done

--- a/benchs/bin/run.ml
+++ b/benchs/bin/run.ml
@@ -52,7 +52,7 @@ let () =
   Printf.printf "n=%d, depth=%d, iters=%n\n%!" !n !depth !iters;
   let comp = mk_company ~n:!n ~depth:!depth in
 
-  let enc = Pbrt.Encoder.create () in
+  let enc = Pbrt.Encoder.create ~size:(64 * 1024) () in
 
   Sys.opaque_identity (Foo.encode_pb_company comp enc);
   let size = String.length @@ Pbrt.Encoder.to_string enc in

--- a/benchs/stubs.c
+++ b/benchs/stubs.c
@@ -5,7 +5,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-inline int pbrt_varint_size(int64_t i) {
+static inline int pbrt_varint_size(int64_t i) {
   int n = 0;
   while (1) {
     n++;
@@ -18,12 +18,12 @@ inline int pbrt_varint_size(int64_t i) {
 }
 
 // number of bytes for i
-CAMLprim value caml_pbrt_varint_size(int64_t i) {
+CAMLprim value b_caml_pbrt_varint_size(int64_t i) {
   int res = pbrt_varint_size(i);
   return Val_int(res);
 }
 
-CAMLprim value caml_pbrt_varint_size_byte(value v_i) {
+CAMLprim value b_caml_pbrt_varint_size_byte(value v_i) {
   CAMLparam1(v_i);
 
   int64_t i = Int64_val(v_i);
@@ -32,7 +32,7 @@ CAMLprim value caml_pbrt_varint_size_byte(value v_i) {
 }
 
 // write i at str[idx…]
-inline void pbrt_varint(unsigned char *str, int64_t i) {
+static inline void pbrt_varint(unsigned char *str, int64_t i) {
   while (true) {
     int64_t cur = i & 0x7f;
     if (cur == i) {
@@ -63,14 +63,14 @@ inline void pbrt_varint(unsigned char *str, int64_t i) {
 //      done
 
 // write `i` starting at `idx`
-CAMLprim value caml_pbrt_varint(value _str, intnat idx, int64_t i) {
+CAMLprim value b_caml_pbrt_varint(value _str, intnat idx, int64_t i) {
   CAMLparam1(_str);
   char *str = Bytes_val(_str);
   pbrt_varint(str + idx, i);
   CAMLreturn(Val_unit);
 }
 
-CAMLprim value caml_pbrt_varint_bytes(value _str, value _idx, value _i) {
+CAMLprim value b_caml_pbrt_varint_bytes(value _str, value _idx, value _i) {
   CAMLparam3(_str, _idx, _i);
   char *str = Bytes_val(_str);
   int idx = Int_val(_idx);

--- a/src/compilerlib/pb_codegen_encode_binary.ml
+++ b/src/compilerlib/pb_codegen_encode_binary.ml
@@ -62,7 +62,7 @@ let gen_encode_field_type ?(with_key = false) sc var_name encoding_number pk
     in
     (match udt.Ot.udt_type with
     | `Message ->
-      F.linep sc "Pbrt.Encoder.nested (%s %s) encoder;" f_name var_name
+      F.linep sc "Pbrt.Encoder.nested %s %s encoder;" f_name var_name
     | `Enum -> F.linep sc "%s %s encoder;" f_name var_name)
   | Ot.Ft_unit ->
     encode_key sc;
@@ -113,24 +113,24 @@ let gen_rft_repeated sc var_name repeated_field =
     gen_encode_field_key sc encoding_number pk is_packed;
     (* When packed the key is encoded once.
        *)
-    F.line sc "Pbrt.Encoder.nested (fun encoder ->";
+    F.line sc "Pbrt.Encoder.nested (fun lst encoder ->";
     F.sub_scope sc (fun sc ->
         F.line sc "List.iter (fun x -> ";
         F.sub_scope sc (fun sc ->
             gen_encode_field_type sc "x" encoding_number pk is_packed field_type);
-        F.linep sc ") %s;" var_name);
-    F.line sc ") encoder;"
+        F.linep sc ") lst;");
+    F.linep sc ") %s encoder;" var_name
   | Ot.Rt_repeated_field, true ->
     gen_encode_field_key sc encoding_number pk is_packed;
     (* When packed the key is encoded once.
        *)
-    F.line sc "Pbrt.Encoder.nested (fun encoder ->";
+    F.line sc "Pbrt.Encoder.nested (fun lst encoder ->";
     F.sub_scope sc (fun sc ->
         F.line sc "Pbrt.Repeated_field.iter (fun x -> ";
         F.sub_scope sc (fun sc ->
             gen_encode_field_type sc "x" encoding_number pk is_packed field_type);
-        F.linep sc ") %s;" var_name);
-    F.line sc ") encoder;"
+        F.linep sc ") lst;");
+    F.linep sc ") %s encoder;" var_name
 
 let gen_rft_variant sc var_name { Ot.v_constructors; _ } =
   F.linep sc "begin match %s with" var_name;

--- a/src/compilerlib/pb_codegen_encode_binary.ml
+++ b/src/compilerlib/pb_codegen_encode_binary.ml
@@ -110,27 +110,25 @@ let gen_rft_repeated sc var_name repeated_field =
           field_type);
     F.linep sc ") %s;" var_name
   | Ot.Rt_list, true ->
-    gen_encode_field_key sc encoding_number pk is_packed;
-    (* When packed the key is encoded once.
-       *)
     F.line sc "Pbrt.Encoder.nested (fun lst encoder ->";
     F.sub_scope sc (fun sc ->
         F.line sc "Pbrt.List_util.rev_iter (fun x -> ";
         F.sub_scope sc (fun sc ->
             gen_encode_field_type sc "x" encoding_number pk is_packed field_type);
         F.linep sc ") lst;");
-    F.linep sc ") %s encoder;" var_name
+    F.linep sc ") %s encoder;" var_name;
+    (* When packed the key is encoded once. *)
+    gen_encode_field_key sc encoding_number pk is_packed
   | Ot.Rt_repeated_field, true ->
-    gen_encode_field_key sc encoding_number pk is_packed;
-    (* When packed the key is encoded once.
-       *)
     F.line sc "Pbrt.Encoder.nested (fun lst encoder ->";
     F.sub_scope sc (fun sc ->
         F.line sc "Pbrt.Repeated_field.rev_iter (fun x -> ";
         F.sub_scope sc (fun sc ->
             gen_encode_field_type sc "x" encoding_number pk is_packed field_type);
         F.linep sc ") lst;");
-    F.linep sc ") %s encoder;" var_name
+    F.linep sc ") %s encoder;" var_name;
+    (* When packed the key is encoded once. *)
+    gen_encode_field_key sc encoding_number pk is_packed
 
 let gen_rft_variant sc var_name { Ot.v_constructors; _ } =
   F.linep sc "begin match %s with" var_name;

--- a/src/compilerlib/pb_codegen_encode_binary.ml
+++ b/src/compilerlib/pb_codegen_encode_binary.ml
@@ -170,16 +170,15 @@ let gen_rft_associative sc var_name associative_field =
   F.line sc ") in";
 
   (match at with
-  | Ot.At_list -> F.line sc "List.iter (fun (k, v) ->"
+  | Ot.At_list -> F.line sc "Pbrt.List_util.rev_iter (fun (k, v) ->"
   | Ot.At_hashtable -> F.line sc "Hashtbl.iter (fun k v ->");
   F.sub_scope sc (fun sc ->
-      gen_encode_field_key sc encoding_number Ot.Pk_bytes false;
       F.linep sc "let map_entry = (k, Pbrt.%s), (v, Pbrt.%s) in"
         (Pb_codegen_util.string_of_payload_kind ~capitalize:() key_pk false)
         (Pb_codegen_util.string_of_payload_kind ~capitalize:() value_pk false);
       F.line sc
-        ("Pbrt.Encoder.map_entry ~encode_key "
-       ^ "~encode_value map_entry encoder"));
+        "Pbrt.Encoder.map_entry ~encode_key ~encode_value map_entry encoder;";
+      gen_encode_field_key sc encoding_number Ot.Pk_bytes false);
   F.linep sc ") %s;" var_name
 
 let gen_record ?and_ { Ot.r_name; r_fields } sc =

--- a/src/compilerlib/pb_codegen_encode_binary.ml
+++ b/src/compilerlib/pb_codegen_encode_binary.ml
@@ -8,7 +8,7 @@ let gen_encode_field_key sc number pk is_packed =
   let pk_runtime_constructor_name =
     Pb_codegen_util.string_of_payload_kind pk is_packed |> constructor_name
   in
-  F.linep sc "Pbrt.Encoder.key (%i, Pbrt.%s) encoder; " number
+  F.linep sc "Pbrt.Encoder.key %i Pbrt.%s encoder; " number
     pk_runtime_constructor_name
 
 let runtime_function_for_basic_type bt pk =

--- a/src/compilerlib/pb_codegen_services.ml
+++ b/src/compilerlib/pb_codegen_services.ml
@@ -87,6 +87,7 @@ let gen_service_client_struct (service : Ot.service) sc : unit =
   let service_name = service.service_name in
   F.line sc "module Client = struct";
   let gen_rpc sc (rpc : Ot.rpc) =
+    F.linep sc "open Pbrt_services";
     let rpc_name = rpc.rpc_name in
     let req, req_mode = ocaml_type_of_rpc_type rpc.rpc_req in
     let req_mode_witness = String.capitalize_ascii req_mode in

--- a/src/compilerlib/pb_codegen_services.ml
+++ b/src/compilerlib/pb_codegen_services.ml
@@ -116,9 +116,7 @@ let gen_service_client_struct (service : Ot.service) sc : unit =
     let res, res_mode = ocaml_type_of_rpc_type rpc.rpc_res in
     F.linep sc "    () : (%s, %s, %s, %s) Client.rpc)" req req_mode res res_mode
   in
-  F.sub_scope sc (fun sc ->
-      F.linep sc "open Pbrt_services";
-      List.iter (gen_rpc sc) service.service_body);
+  F.sub_scope sc (fun sc -> List.iter (gen_rpc sc) service.service_body);
   F.line sc "end"
 
 let gen_service_server_struct (service : Ot.service) sc : unit =

--- a/src/examples/dune
+++ b/src/examples/dune
@@ -65,3 +65,15 @@
  (modules file_server) ; just check that it compiles
  (package pbrt_services)
  (libraries pbrt pbrt_yojson pbrt_services))
+
+(rule
+ (targets orgchart.ml orgchart.mli)
+ (deps orgchart.proto)
+ (action
+  (run ocaml-protoc --pp --binary --ml_out ./ %{deps})))
+
+(test
+ (name orgchart_ml)
+ (modules orgchart orgchart_ml)
+ (package pbrt)
+ (libraries pbrt))

--- a/src/examples/orgchart.proto
+++ b/src/examples/orgchart.proto
@@ -1,0 +1,19 @@
+
+syntax = "proto3";
+
+message Person {
+  string name = 1;
+  sint64 age = 2;
+}
+
+message Store {
+  string address = 1;
+  repeated Person employees = 2;
+  repeated Person clients = 3;
+}
+
+message Company {
+  string name = 1;
+  repeated Store stores = 2;
+  repeated Company subsidiaries = 3;
+}

--- a/src/examples/orgchart_ml.ml
+++ b/src/examples/orgchart_ml.ml
@@ -1,0 +1,81 @@
+open Orgchart
+
+let spf = Printf.sprintf
+
+(* company, with [n] stores and [2^depth] subsidiaries *)
+let rec mk_company ~n ~depth : company =
+  {
+    name = "bigcorp";
+    subsidiaries =
+      (if depth = 0 then
+        []
+      else (
+        let c = mk_company ~n ~depth:(depth - 1) in
+        [ c; c ]
+      ));
+    stores =
+      List.init n (fun i ->
+          {
+            address = spf "%d foobar street" i;
+            clients =
+              List.init 2 (fun j ->
+                  {
+                    name = spf "client_%d_%d" i j;
+                    age = Int64.of_int ((j mod 30) + 15);
+                  });
+            employees =
+              List.init 2 (fun j ->
+                  {
+                    name = spf "employee_%d_%d" i j;
+                    age = Int64.of_int ((j mod 30) + 18);
+                  });
+          });
+  }
+
+let test ~n ~depth () : unit =
+  let c = mk_company ~n ~depth in
+  let enc = Pbrt.Encoder.create () in
+  encode_pb_company c enc;
+  let str = Pbrt.Encoder.to_string enc in
+  let c2 =
+    let dec = Pbrt.Decoder.of_string str in
+    decode_pb_company dec
+  in
+
+  if c <> c2 then (
+    Format.eprintf "c=%a@." pp_company c;
+    Format.eprintf "dec(enc(c))=%a@." pp_company c2;
+    failwith @@ spf "failed for n=%d, depth=%d" n depth
+  )
+(* else Printf.eprintf "ok for n=%d, depth=%d\n%!" n depth *)
+
+let () =
+  List.iter
+    (fun (n, depth) -> test ~n ~depth ())
+    [
+      1, 1;
+      1, 1;
+      1, 4;
+      1, 6;
+      1, 10;
+      2, 1;
+      2, 4;
+      2, 6;
+      2, 10;
+      5, 1;
+      5, 4;
+      5, 6;
+      10, 1;
+      10, 2;
+      10, 3;
+      10, 4;
+      20, 1;
+      50, 1;
+      20, 3;
+      20, 4;
+      50, 1;
+      50, 3;
+      50, 4;
+      100, 1;
+      100, 3;
+    ]

--- a/src/runtime/dune
+++ b/src/runtime/dune
@@ -2,6 +2,7 @@
  (name pbrt)
  (public_name pbrt)
  (synopsis "Runtime library for ocaml-protoc")
+ (foreign_stubs (language c) (flags :standard -std=c99 -O2) (names stubs))
  ; we need to increase -inline, so that the varint encoder/decoder can
  ; be remembered by the inliner.
  (ocamlopt_flags :standard -inline 100))

--- a/src/runtime/pbrt.ml
+++ b/src/runtime/pbrt.ml
@@ -724,7 +724,7 @@ module Repeated_field = struct
     List.iter
       (fun a ->
         let len = Array.length a - 1 in
-        for j = len to 0 do
+        for j = len downto 0 do
           f (Array.unsafe_get a j)
         done)
       l

--- a/src/runtime/pbrt.ml
+++ b/src/runtime/pbrt.ml
@@ -373,9 +373,10 @@ module Encoder = struct
         | _ -> None)
 
   type t = {
-    mutable b: bytes;
+    mutable b: bytes;  (** Slice of bytes (already written: [start…]) *)
     mutable start: int;
-    initial: bytes;
+        (** Start of the slice in which data have been written *)
+    initial: bytes;  (** Initial buffer, for {!reset} *)
   }
 
   let create () =

--- a/src/runtime/pbrt.ml
+++ b/src/runtime/pbrt.ml
@@ -379,8 +379,8 @@ module Encoder = struct
     initial: bytes;  (** Initial buffer, for {!reset} *)
   }
 
-  let create () =
-    let len = 16 in
+  let create ?(size = 16) () =
+    let len = max size 16 in
     let b = Bytes.create len in
     { b; start = len; initial = b }
 

--- a/src/runtime/pbrt.ml
+++ b/src/runtime/pbrt.ml
@@ -477,7 +477,7 @@ module Encoder = struct
     add_bytes e b;
     int_as_varint (Bytes.length b) e
 
-  let nested f x e =
+  let[@inline] nested f x e =
     (* compute length because it's not affected by a resize during
        the call to [f] *)
     let old_len = cap e - e.start in

--- a/src/runtime/pbrt.ml
+++ b/src/runtime/pbrt.ml
@@ -533,7 +533,7 @@ module Encoder = struct
   let uint64_as_bits64 = function
     | `unsigned x -> bits64 x
 
-  let bool b e =
+  let[@inline] bool b e =
     add_char e
       (Char.unsafe_chr
          (if b then
@@ -546,7 +546,7 @@ module Encoder = struct
   let[@inline] int_as_bits32 i e = bits32 (Int32.of_int i) e
   let[@inline] int_as_bits64 i e = bits64 (Int64.of_int i) e
 
-  let string s e =
+  let[@inline] string s e =
     (* safe: we're not going to modify the bytes, and [s] will
        not change. *)
     bytes (Bytes.unsafe_of_string s) e

--- a/src/runtime/pbrt.ml
+++ b/src/runtime/pbrt.ml
@@ -616,17 +616,32 @@ module Encoder = struct
 end
 
 module List_util = struct
-  let rev_iter f l =
+  let[@inline] rev_iter f l =
     let safe f l = List.iter f @@ List.rev l in
     let rec direct i f l =
       match l with
       | [] -> ()
+      | [ x ] -> f x
+      | [ x; y ] ->
+        f y;
+        f x
       | _ when i = 0 -> safe f l
-      | x :: tl ->
+      | x :: y :: tl ->
         direct (i - 1) f tl;
+        f y;
         f x
     in
-    direct 200 f l
+
+    match l with
+    | [] -> ()
+    | [ x ] -> f x
+    | [ x; y ] ->
+      f y;
+      f x
+    | x :: y :: tl ->
+      direct 200 f tl;
+      f y;
+      f x
 end
 
 module Repeated_field = struct

--- a/src/runtime/pbrt.ml
+++ b/src/runtime/pbrt.ml
@@ -467,9 +467,12 @@ module Encoder = struct
     int_as_varint (Bytes.length b) e
 
   let nested f x e =
-    let old_start = e.start in
+    (* compute length because it's not affected by a resize during
+       the call to [f] *)
+    let old_len = cap e - e.start in
     f x e;
-    let size = old_start - e.start in
+    let new_len = cap e - e.start in
+    let size = new_len - old_len in
     int_as_varint size e
 
   let[@inline] key (k, pk) e =

--- a/src/runtime/pbrt.ml
+++ b/src/runtime/pbrt.ml
@@ -391,9 +391,14 @@ module Encoder = struct
     self.b <- self.initial;
     self.start <- cap self
 
-  let to_string self = Bytes.sub_string self.b self.start (cap self - self.start)
-  let to_bytes self = Bytes.sub self.b self.start (cap self - self.start)
-  let write_chunks w self = w self.b self.start (cap self - self.start)
+  let[@inline] to_string self =
+    Bytes.sub_string self.b self.start (cap self - self.start)
+
+  let[@inline] to_bytes self =
+    Bytes.sub self.b self.start (cap self - self.start)
+
+  let[@inline] write_chunks w self : unit =
+    w self.b self.start (cap self - self.start)
 
   let next_cap_ self =
     min Sys.max_string_length

--- a/src/runtime/pbrt.ml
+++ b/src/runtime/pbrt.ml
@@ -475,7 +475,7 @@ module Encoder = struct
     let size = new_len - old_len in
     int_as_varint size e
 
-  let[@inline] key (k, pk) e =
+  let[@inline] key k pk e =
     let pk' =
       match pk with
       | Varint -> 0
@@ -490,9 +490,9 @@ module Encoder = struct
       (fun kv t ->
         let (key_value, key_pk), (value_value, value_pk) = kv in
         encode_value value_value t;
-        key (2, value_pk) t;
+        key 2 value_pk t;
         encode_key key_value t;
-        key (1, key_pk) t)
+        key 1 key_pk t)
       kv t
 
   let empty_nested e = add_char e (Char.unsafe_chr 0)
@@ -540,18 +540,14 @@ module Encoder = struct
        not change. *)
     bytes (Bytes.unsafe_of_string s) e
 
-  let double_value_key = 1, Bits64
-
   let wrapper_double_value v e =
     nested
       (fun v e ->
         (match v with
         | None -> ()
         | Some f -> float_as_bits64 f e);
-        key double_value_key e)
+        key 1 Bits64 e)
       v e
-
-  let float_value_key = 1, Bits32
 
   let wrapper_float_value v e =
     nested
@@ -559,10 +555,8 @@ module Encoder = struct
         (match v with
         | None -> ()
         | Some f -> float_as_bits32 f e);
-        key float_value_key e)
+        key 1 Bits32 e)
       v e
-
-  let int64_value_key = 1, Varint
 
   let wrapper_int64_value v e =
     nested
@@ -570,10 +564,8 @@ module Encoder = struct
         (match v with
         | None -> ()
         | Some i -> int64_as_varint i e);
-        key int64_value_key e)
+        key 1 Varint e)
       v e
-
-  let int32_value_key = 1, Varint
 
   let wrapper_int32_value v e =
     nested
@@ -581,10 +573,8 @@ module Encoder = struct
         (match v with
         | None -> ()
         | Some i -> int32_as_varint i e);
-        key int32_value_key e)
+        key 1 Varint e)
       v e
-
-  let bool_value_key = 1, Varint
 
   let wrapper_bool_value v e =
     nested
@@ -592,10 +582,8 @@ module Encoder = struct
         (match v with
         | None -> ()
         | Some b -> bool b e);
-        key bool_value_key e)
+        key 1 Varint e)
       v e
-
-  let string_value_key = 1, Bytes
 
   let wrapper_string_value v e =
     nested
@@ -603,10 +591,8 @@ module Encoder = struct
         (match v with
         | None -> ()
         | Some s -> string s e);
-        key string_value_key e)
+        key 1 Bytes e)
       v e
-
-  let bytes_value_key = 1, Bytes
 
   let wrapper_bytes_value v e =
     nested
@@ -614,7 +600,7 @@ module Encoder = struct
         (match v with
         | None -> ()
         | Some b -> bytes b e);
-        key bytes_value_key e)
+        key 1 Bytes e)
       v e
 end
 

--- a/src/runtime/pbrt.mli
+++ b/src/runtime/pbrt.mli
@@ -285,8 +285,8 @@ module Encoder : sig
   val key : int * payload_kind -> t -> unit
   (** [key (k, pk) e] writes a key and a payload kind to [e]. *)
 
-  val nested : (t -> unit) -> t -> unit
-  (** [nested f e] applies [f] to an encoder for a message nested in [e]. *)
+  val nested : ('a -> t -> unit) -> 'a -> t -> unit
+  (** [nested f x e] applies [f x] to an encoder for a message nested in [e]. *)
 
   val map_entry :
     encode_key:('a -> t -> unit) ->

--- a/src/runtime/pbrt.mli
+++ b/src/runtime/pbrt.mli
@@ -283,8 +283,8 @@ module Encoder : sig
       These combinators are used by generated code (or user combinators)
       to encode a OCaml value into the wire representation of protobufs. *)
 
-  val key : int * payload_kind -> t -> unit
-  (** [key (k, pk) e] writes a key and a payload kind to [e]. *)
+  val key : int -> payload_kind -> t -> unit
+  (** [key k pk e] writes a key and a payload kind to [e]. *)
 
   val nested : ('a -> t -> unit) -> 'a -> t -> unit
   (** [nested f x e] applies [f x] to an encoder for a message nested in [e]. *)

--- a/src/runtime/pbrt.mli
+++ b/src/runtime/pbrt.mli
@@ -362,6 +362,11 @@ module Encoder : sig
   val wrapper_bytes_value : bytes option -> t -> unit
 end
 
+module List_util : sig
+  val rev_iter : ('a -> unit) -> 'a list -> unit
+  (** [iter_rev f l] iterate over the list in reverse order *)
+end
+
 (** Optimized representation for repeated fields *)
 module Repeated_field : sig
   type 'a t
@@ -417,6 +422,8 @@ module Repeated_field : sig
 
   val iteri : (int -> 'a -> unit) -> 'a t -> unit
   (** [iteri f c] applies [f] to all element in [c] *)
+
+  val rev_iter : ('a -> unit) -> 'a t -> unit
 
   val fold_left : ('b -> 'a -> 'b) -> 'b -> 'a t -> 'b
   (** [fold_left f e0 c] accumulates [e0] through each elements *)

--- a/src/runtime/pbrt.mli
+++ b/src/runtime/pbrt.mli
@@ -246,12 +246,13 @@ module Encoder : sig
 
   (** {2 Creator} *)
 
-  val create : unit -> t
+  val create : ?size:int -> unit -> t
   (** Create a new encoder. *)
 
   val clear : t -> unit
   (** Clear the content of the internal buffer(s), but does not release memory.
       This makes the encoder ready to encode another message.
+      @param size initial size in bytes
       @since 2.1 *)
 
   val reset : t -> unit

--- a/src/runtime/stubs.c
+++ b/src/runtime/stubs.c
@@ -56,10 +56,9 @@ static inline void pbrt_varint(unsigned char *str, uint64_t i) {
 
 // write `i` starting at `idx`
 CAMLprim value caml_pbrt_varint(value _str, intnat idx, int64_t i) {
-  CAMLparam1(_str);
   char *str = Bytes_val(_str);
   pbrt_varint(str + idx, i);
-  CAMLreturn(Val_unit);
+  return Val_unit;
 }
 
 CAMLprim value caml_pbrt_varint_byte(value _str, value _idx, value _i) {

--- a/src/runtime/stubs.c
+++ b/src/runtime/stubs.c
@@ -22,20 +22,6 @@ for i in range(1,10):
   if (i <= 72057594037927935L) return 8;
   if (i <= 9223372036854775807L) return 9;
   return 10;
-
-  /*
-  if (i <= 127L) return 1;
-
-  int n = 0;
-  while (true) {
-    n++;
-    uint64_t cur = i & 0x7f;
-    if (cur == i)
-      break;
-    i = i >> 7;
-  }
-  return n;
-  */
 }
 
 // number of bytes for i

--- a/src/runtime/stubs.c
+++ b/src/runtime/stubs.c
@@ -1,0 +1,86 @@
+
+#include <caml/alloc.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+static inline int pbrt_varint_size(uint64_t i) {
+/* generated with:
+for i in range(1,10):
+  ceiling = (1 << (i*7))-1
+  print(f'if (i <= {ceiling}L) return {i};')
+*/
+
+  if (i <= 127L) return 1;
+  if (i <= 16383L) return 2;
+  if (i <= 2097151L) return 3;
+  if (i <= 268435455L) return 4;
+  if (i <= 34359738367L) return 5;
+  if (i <= 4398046511103L) return 6;
+  if (i <= 562949953421311L) return 7;
+  if (i <= 72057594037927935L) return 8;
+  if (i <= 9223372036854775807L) return 9;
+  return 10;
+
+  /*
+  if (i <= 127L) return 1;
+
+  int n = 0;
+  while (true) {
+    n++;
+    uint64_t cur = i & 0x7f;
+    if (cur == i)
+      break;
+    i = i >> 7;
+  }
+  return n;
+  */
+}
+
+// number of bytes for i
+CAMLprim value caml_pbrt_varint_size(int64_t i) {
+  int res = pbrt_varint_size(i);
+  return Val_int(res);
+}
+
+// boxed version, for bytecode
+CAMLprim value caml_pbrt_varint_size_byte(value v_i) {
+  CAMLparam1(v_i);
+
+  int64_t i = Int64_val(v_i);
+  int res = pbrt_varint_size(i);
+  CAMLreturn(Val_int(res));
+}
+
+// write i at str[idx…] in varint
+static inline void pbrt_varint(unsigned char *str, uint64_t i) {
+  while (true) {
+    uint64_t cur = i & 0x7f;
+    if (cur == i) {
+      *str = (unsigned char)cur;
+      break;
+    } else {
+      *str = (unsigned char)(cur | 0x80);
+      i = i >> 7;
+      ++str;
+    }
+  }
+}
+
+// write `i` starting at `idx`
+CAMLprim value caml_pbrt_varint(value _str, intnat idx, int64_t i) {
+  CAMLparam1(_str);
+  char *str = Bytes_val(_str);
+  pbrt_varint(str + idx, i);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value caml_pbrt_varint_byte(value _str, value _idx, value _i) {
+  CAMLparam3(_str, _idx, _i);
+  char *str = Bytes_val(_str);
+  int idx = Int_val(_idx);
+  int64_t i = Int64_val(_idx);
+  pbrt_varint(str + idx, i);
+  CAMLreturn(Val_unit);
+}

--- a/src/tests/unit-tests/wrapper_encoding.ml
+++ b/src/tests/unit-tests/wrapper_encoding.ml
@@ -1,30 +1,44 @@
 (* unit tests for the wrapper specific encoding *)
 
-let do_test encode decode v =
+let spf = Printf.sprintf
+
+let do_test pp encode decode v =
   let e = Pbrt.Encoder.create () in
   encode (Some v) e;
   let b = Pbrt.Encoder.to_bytes e in
+  (* Printf.printf "encoded: %S for %s\n" (Bytes.unsafe_to_string b) (pp v); *)
   let d = Pbrt.Decoder.of_bytes b in
   match decode d with
   | Some x when x = v -> ()
+  | Some y ->
+    Printf.eprintf "expected %s, got %s\n%!" (pp v) (pp y);
+    assert false
   | _ -> assert false
 
 let round32 v =
   let open Int32 in
   v |> bits_of_float |> float_of_bits
 
+let pp_bytes b = spf "%S" (Bytes.unsafe_to_string b)
+
 let () =
   let open Pbrt in
-  do_test Encoder.wrapper_double_value Decoder.wrapper_double_value 1.23;
-  do_test Encoder.wrapper_float_value Decoder.wrapper_float_value (round32 1.23);
-  do_test Encoder.wrapper_int64_value Decoder.wrapper_int64_value 123L;
-  do_test Encoder.wrapper_int32_value Decoder.wrapper_int32_value 123l;
-  do_test Encoder.wrapper_bool_value Decoder.wrapper_bool_value true;
-  do_test Encoder.wrapper_bool_value Decoder.wrapper_bool_value false;
-  do_test Encoder.wrapper_string_value Decoder.wrapper_string_value "";
-  do_test Encoder.wrapper_string_value Decoder.wrapper_string_value "abc";
-  do_test Encoder.wrapper_bytes_value Decoder.wrapper_bytes_value
+  do_test (spf "%f") Encoder.wrapper_double_value Decoder.wrapper_double_value
+    1.23;
+  do_test (spf "%f") Encoder.wrapper_float_value Decoder.wrapper_float_value
+    (round32 1.23);
+  do_test (spf "%LdL") Encoder.wrapper_int64_value Decoder.wrapper_int64_value
+    123L;
+  do_test (spf "%ldl") Encoder.wrapper_int32_value Decoder.wrapper_int32_value
+    123l;
+  do_test (spf "%b") Encoder.wrapper_bool_value Decoder.wrapper_bool_value true;
+  do_test (spf "%b") Encoder.wrapper_bool_value Decoder.wrapper_bool_value false;
+  do_test (spf "%S") Encoder.wrapper_string_value Decoder.wrapper_string_value
+    "";
+  do_test (spf "%S") Encoder.wrapper_string_value Decoder.wrapper_string_value
+    "abc";
+  do_test pp_bytes Encoder.wrapper_bytes_value Decoder.wrapper_bytes_value
     (Bytes.of_string "");
-  do_test Encoder.wrapper_bytes_value Decoder.wrapper_bytes_value
+  do_test pp_bytes Encoder.wrapper_bytes_value Decoder.wrapper_bytes_value
     (Bytes.of_string "abc");
   ()


### PR DESCRIPTION
rationale: encoding backward means we can use a single buffer even in the presence of nested messages. We encode from the end, in reverse order, which means we encode the sub-message before having to write its size; so when it's time to write the size we know it and we can just write the varint. If we write forward we cannot do that because we don't know how much space to leave in front to encode the length as a varint.

The C stubs are there to make varint operations faster: computing how many bytes a varint takes (so we can allocate a little slice for it in the buffer); and writing the varint into this slice.

Note that we also require OCaml >= 4.08 so we can rely on Bytes' operations for fixed-size bits32/bits64.