### PR TITLE
Add documentation for dune and deriving

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,16 @@ Using dune, the program can be compiled with:
   (libraries pbrt))
 ```
 
+And the `example.proto` can be compiled with:
+```
+(rule
+ (targets example.ml example.mli)
+ (deps
+  (:proto example.proto))
+ (action
+  (run ocaml-protoc %{proto} --binary --ml_out .)))
+```
+
 More manually, the program can be built directly using [ocamlfind](http://projects.camlcity.org/projects/findlib.html):
 
 ```Bash

--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ Online documentation [here](https://mransan.github.io/ocaml-protoc/dev/pbrt/Pbrt
 | --bs | BuckleScript encoding using the BuckleScript core binding to JS json library | [bs-ocaml-protoc-json][3] |
 | --pp | pretty printing functions based on the Format module. | `pbrt` |
 | --services | RPC definitions. | `pbrt_services` |
+| --ocaml_all_types_ppx | Extend generated types with PPXs, e.g. allow deriving Eq,Ord  | |
+
 
 [3]:https://www.npmjs.com/package/bs-ocaml-protoc-json
 


### PR DESCRIPTION
Two small additions for; How to use ocaml-protoc with a dune rule for generating code, and How to extend generated types with PPX deriving. Neither option was obvious to me when picking up the library the first time and they might be useful to other new people.