### PR TITLE
Expose individual server RPC endpoints for advanced users

### DIFF
--- a/src/compilerlib/pb_codegen_util.ml
+++ b/src/compilerlib/pb_codegen_util.ml
@@ -90,7 +90,14 @@ let module_type_name_of_service_client (service : Ot.service) : string =
 let module_type_name_of_service_server (service : Ot.service) : string =
   String.uppercase_ascii service.service_name ^ "_SERVER"
 
-let function_name_of_rpc (rpc : Ot.rpc) = String.uncapitalize_ascii rpc.rpc_name
+let function_name_of_rpc_reserved_keywords_list = [ "make" ]
+
+let function_name_of_rpc (rpc : Ot.rpc) =
+  let candidate = String.uncapitalize_ascii rpc.rpc_name in
+  if List.mem candidate function_name_of_rpc_reserved_keywords_list then
+    candidate ^ "_"
+  else
+    candidate
 
 let caml_file_name_of_proto_file_name ~proto_file_name =
   let splitted = Pb_util.rev_split_by_char '.' proto_file_name in

--- a/src/examples/build_server.ml.expected
+++ b/src/examples/build_server.ml.expected
@@ -1,0 +1,159 @@
+[@@@ocaml.warning "-27-30-39"]
+
+type file_path = {
+  path : string;
+}
+
+type empty = unit
+
+let rec default_file_path 
+  ?path:((path:string) = "")
+  () : file_path  = {
+  path;
+}
+
+let rec default_empty = ()
+
+type file_path_mutable = {
+  mutable path : string;
+}
+
+let default_file_path_mutable () : file_path_mutable = {
+  path = "";
+}
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Formatters} *)
+
+let rec pp_file_path fmt (v:file_path) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "path" Pbrt.Pp.pp_string fmt v.path;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_empty fmt (v:empty) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_unit fmt ()
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Protobuf Encoding} *)
+
+let rec encode_pb_file_path (v:file_path) encoder = 
+  Pbrt.Encoder.string v.path encoder;
+  Pbrt.Encoder.key 1 Pbrt.Bytes encoder; 
+  ()
+
+let rec encode_pb_empty (v:empty) encoder = 
+()
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Protobuf Decoding} *)
+
+let rec decode_pb_file_path d =
+  let v = default_file_path_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.path <- Pbrt.Decoder.string d;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(file_path), field(1)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    path = v.path;
+  } : file_path)
+
+let rec decode_pb_empty d =
+  match Pbrt.Decoder.key d with
+  | None -> ();
+  | Some (_, pk) -> 
+    Pbrt.Decoder.unexpected_payload "Unexpected fields in empty message(empty)" pk
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Protobuf YoJson Encoding} *)
+
+let rec encode_json_file_path (v:file_path) = 
+  let assoc = [] in 
+  let assoc = ("path", Pbrt_yojson.make_string v.path) :: assoc in
+  `Assoc assoc
+
+let rec encode_json_empty (v:empty) = 
+Pbrt_yojson.make_unit v
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 JSON Decoding} *)
+
+let rec decode_json_file_path d =
+  let v = default_file_path_mutable () in
+  let assoc = match d with
+    | `Assoc assoc -> assoc
+    | _ -> assert(false)
+  in
+  List.iter (function 
+    | ("path", json_value) -> 
+      v.path <- Pbrt_yojson.string json_value "file_path" "path"
+    
+    | (_, _) -> () (*Unknown fields are ignored*)
+  ) assoc;
+  ({
+    path = v.path;
+  } : file_path)
+
+let rec decode_json_empty d =
+Pbrt_yojson.unit d "empty" "empty record"
+
+module BuildServer = struct
+  open Pbrt_services.Value_mode
+  module Client = struct
+    open Pbrt_services
+    
+    let make : (file_path, unary, empty, unary) Client.rpc =
+      (Client.mk_rpc 
+        ~package:[]
+        ~service_name:"BuildServer" ~rpc_name:"make"
+        ~req_mode:Client.Unary
+        ~res_mode:Client.Unary
+        ~encode_json_req:encode_json_file_path
+        ~encode_pb_req:encode_pb_file_path
+        ~decode_json_res:decode_json_empty
+        ~decode_pb_res:decode_pb_empty
+        () : (file_path, unary, empty, unary) Client.rpc)
+  end
+  
+  module Server = struct
+    open Pbrt_services
+    
+    let _rpc_make : (file_path,unary,empty,unary) Server.rpc = 
+      (Server.mk_rpc ~name:"make"
+        ~req_mode:Server.Unary
+        ~res_mode:Server.Unary
+        ~encode_json_res:encode_json_empty
+        ~encode_pb_res:encode_pb_empty
+        ~decode_json_req:decode_json_file_path
+        ~decode_pb_req:decode_pb_file_path
+        () : _ Server.rpc)
+    
+    let make
+      ~make
+      () : _ Server.t =
+      { Server.
+        service_name="BuildServer";
+        package=[];
+        handlers=[
+           (make _rpc_make);
+        ];
+      }
+  end
+  
+end

--- a/src/examples/build_server.ml.expected
+++ b/src/examples/build_server.ml.expected
@@ -118,7 +118,7 @@ module BuildServer = struct
   module Client = struct
     open Pbrt_services
     
-    let make : (file_path, unary, empty, unary) Client.rpc =
+    let make_ : (file_path, unary, empty, unary) Client.rpc =
       (Client.mk_rpc 
         ~package:[]
         ~service_name:"BuildServer" ~rpc_name:"make"
@@ -134,7 +134,7 @@ module BuildServer = struct
   module Server = struct
     open Pbrt_services
     
-    let _rpc_make : (file_path,unary,empty,unary) Server.rpc = 
+    let make_ : (file_path,unary,empty,unary) Server.rpc = 
       (Server.mk_rpc ~name:"make"
         ~req_mode:Server.Unary
         ~res_mode:Server.Unary
@@ -145,13 +145,13 @@ module BuildServer = struct
         () : _ Server.rpc)
     
     let make
-      ~make
+      ~make_:__handler__make_
       () : _ Server.t =
       { Server.
         service_name="BuildServer";
         package=[];
         handlers=[
-           (make _rpc_make);
+           (__handler__make_ make_);
         ];
       }
   end

--- a/src/examples/build_server.mli.expected
+++ b/src/examples/build_server.mli.expected
@@ -80,13 +80,17 @@ module BuildServer : sig
   
   module Client : sig
     
-    val make : (file_path, unary, empty, unary) Client.rpc
+    val make_ : (file_path, unary, empty, unary) Client.rpc
   end
   
   module Server : sig
     (** Produce a server implementation from handlers *)
     val make : 
-      make:((file_path, unary, empty, unary) Server.rpc -> 'handler) ->
+      make_:((file_path, unary, empty, unary) Server.rpc -> 'handler) ->
       unit -> 'handler Pbrt_services.Server.t
+    
+    (** The individual server stubs are only exposed for advanced users. Casual users should prefer accessing them through {!make}. *)
+    
+    val make_ : (file_path,unary,empty,unary) Server.rpc
   end
 end

--- a/src/examples/build_server.mli.expected
+++ b/src/examples/build_server.mli.expected
@@ -1,0 +1,92 @@
+
+(** Code for build_server.proto *)
+
+(* generated from "build_server.proto", do not edit *)
+
+
+
+(** {2 Types} *)
+
+type file_path = {
+  path : string;
+}
+
+type empty = unit
+
+
+(** {2 Basic values} *)
+
+val default_file_path : 
+  ?path:string ->
+  unit ->
+  file_path
+(** [default_file_path ()] is the default value for type [file_path] *)
+
+val default_empty : unit
+(** [default_empty ()] is the default value for type [empty] *)
+
+
+(** {2 Formatters} *)
+
+val pp_file_path : Format.formatter -> file_path -> unit 
+(** [pp_file_path v] formats v *)
+
+val pp_empty : Format.formatter -> empty -> unit 
+(** [pp_empty v] formats v *)
+
+
+(** {2 Protobuf Encoding} *)
+
+val encode_pb_file_path : file_path -> Pbrt.Encoder.t -> unit
+(** [encode_pb_file_path v encoder] encodes [v] with the given [encoder] *)
+
+val encode_pb_empty : empty -> Pbrt.Encoder.t -> unit
+(** [encode_pb_empty v encoder] encodes [v] with the given [encoder] *)
+
+
+(** {2 Protobuf Decoding} *)
+
+val decode_pb_file_path : Pbrt.Decoder.t -> file_path
+(** [decode_pb_file_path decoder] decodes a [file_path] binary value from [decoder] *)
+
+val decode_pb_empty : Pbrt.Decoder.t -> empty
+(** [decode_pb_empty decoder] decodes a [empty] binary value from [decoder] *)
+
+
+(** {2 Protobuf YoJson Encoding} *)
+
+val encode_json_file_path : file_path -> Yojson.Basic.t
+(** [encode_json_file_path v encoder] encodes [v] to to json *)
+
+val encode_json_empty : empty -> Yojson.Basic.t
+(** [encode_json_empty v encoder] encodes [v] to to json *)
+
+
+(** {2 JSON Decoding} *)
+
+val decode_json_file_path : Yojson.Basic.t -> file_path
+(** [decode_json_file_path decoder] decodes a [file_path] value from [decoder] *)
+
+val decode_json_empty : Yojson.Basic.t -> empty
+(** [decode_json_empty decoder] decodes a [empty] value from [decoder] *)
+
+
+(** {2 Services} *)
+
+(** BuildServer service *)
+module BuildServer : sig
+  open Pbrt_services
+  open Pbrt_services.Value_mode
+  
+  module Client : sig
+    
+    val make : (file_path, unary, empty, unary) Client.rpc
+  end
+  
+  module Server : sig
+    (** Produce a server implementation from handlers *)
+    val make : 
+      make:((file_path, unary, empty, unary) Server.rpc -> 'handler) ->
+      unit -> 'handler Pbrt_services.Server.t
+  end
+end

--- a/src/examples/build_server.proto
+++ b/src/examples/build_server.proto
@@ -1,0 +1,12 @@
+// test that calling an RPC 'make' doesn't break the generated code
+
+syntax = "proto3";
+
+message FilePath { string path = 1; }
+
+message Empty {}
+
+service BuildServer {
+  // Run 'make' in the given directory.
+  rpc make(FilePath) returns (Empty);
+}

--- a/src/examples/calculator.ml.expected
+++ b/src/examples/calculator.ml.expected
@@ -363,7 +363,7 @@ module Calculator = struct
   module Server = struct
     open Pbrt_services
     
-    let _rpc_add : (add_req,unary,i32,unary) Server.rpc = 
+    let add : (add_req,unary,i32,unary) Server.rpc = 
       (Server.mk_rpc ~name:"add"
         ~req_mode:Server.Unary
         ~res_mode:Server.Unary
@@ -373,7 +373,7 @@ module Calculator = struct
         ~decode_pb_req:decode_pb_add_req
         () : _ Server.rpc)
     
-    let _rpc_add_all : (add_all_req,unary,i32,unary) Server.rpc = 
+    let add_all : (add_all_req,unary,i32,unary) Server.rpc = 
       (Server.mk_rpc ~name:"add_all"
         ~req_mode:Server.Unary
         ~res_mode:Server.Unary
@@ -383,7 +383,7 @@ module Calculator = struct
         ~decode_pb_req:decode_pb_add_all_req
         () : _ Server.rpc)
     
-    let _rpc_ping : (empty,unary,empty,unary) Server.rpc = 
+    let ping : (empty,unary,empty,unary) Server.rpc = 
       (Server.mk_rpc ~name:"ping"
         ~req_mode:Server.Unary
         ~res_mode:Server.Unary
@@ -393,7 +393,7 @@ module Calculator = struct
         ~decode_pb_req:decode_pb_empty
         () : _ Server.rpc)
     
-    let _rpc_get_pings : (empty,unary,i32,unary) Server.rpc = 
+    let get_pings : (empty,unary,i32,unary) Server.rpc = 
       (Server.mk_rpc ~name:"get_pings"
         ~req_mode:Server.Unary
         ~res_mode:Server.Unary
@@ -404,19 +404,19 @@ module Calculator = struct
         () : _ Server.rpc)
     
     let make
-      ~add
-      ~add_all
-      ~ping
-      ~get_pings
+      ~add:__handler__add
+      ~add_all:__handler__add_all
+      ~ping:__handler__ping
+      ~get_pings:__handler__get_pings
       () : _ Server.t =
       { Server.
         service_name="Calculator";
         package=[];
         handlers=[
-           (add _rpc_add);
-           (add_all _rpc_add_all);
-           (ping _rpc_ping);
-           (get_pings _rpc_get_pings);
+           (__handler__add add);
+           (__handler__add_all add_all);
+           (__handler__ping ping);
+           (__handler__get_pings get_pings);
         ];
       }
   end

--- a/src/examples/calculator.mli.expected
+++ b/src/examples/calculator.mli.expected
@@ -169,5 +169,15 @@ module Calculator : sig
       ping:((empty, unary, empty, unary) Server.rpc -> 'handler) ->
       get_pings:((empty, unary, i32, unary) Server.rpc -> 'handler) ->
       unit -> 'handler Pbrt_services.Server.t
+    
+    (** The individual server stubs are only exposed for advanced users. Casual users should prefer accessing them through {!make}. *)
+    
+    val add : (add_req,unary,i32,unary) Server.rpc
+    
+    val add_all : (add_all_req,unary,i32,unary) Server.rpc
+    
+    val ping : (empty,unary,empty,unary) Server.rpc
+    
+    val get_pings : (empty,unary,i32,unary) Server.rpc
   end
 end

--- a/src/examples/dune
+++ b/src/examples/dune
@@ -82,6 +82,18 @@
  (package ocaml-protoc)
  (libraries pbrt))
 
+(rule
+ (targets build_server.ml build_server.mli)
+ (deps build_server.proto)
+ (action
+  (run ocaml-protoc --binary --pp --yojson --services --ml_out ./ %{deps})))
+
+(test
+ (name build_server)
+ (modules build_server) ; just check that it compiles
+ (package ocaml-protoc)
+ (libraries pbrt pbrt_yojson pbrt_services))
+
 (include dune.inc)
 
 (rule
@@ -97,6 +109,7 @@
    dune.inc.gen
    (run
     %{gen-dune}
+    build_server
     calculator
     example01
     example03

--- a/src/examples/dune.inc
+++ b/src/examples/dune.inc
@@ -3,6 +3,16 @@
 (rule
  (alias runtest)
  (action
+  (diff build_server.ml.expected build_server.ml)))
+
+(rule
+ (alias runtest)
+ (action
+  (diff build_server.mli.expected build_server.mli)))
+
+(rule
+ (alias runtest)
+ (action
   (diff calculator.ml.expected calculator.ml)))
 
 (rule

--- a/src/examples/file_server.ml.expected
+++ b/src/examples/file_server.ml.expected
@@ -395,7 +395,7 @@ module FileServer = struct
   module Server = struct
     open Pbrt_services
     
-    let _rpc_touch_file : (file_path,unary,empty,unary) Server.rpc = 
+    let touch_file : (file_path,unary,empty,unary) Server.rpc = 
       (Server.mk_rpc ~name:"touch_file"
         ~req_mode:Server.Unary
         ~res_mode:Server.Unary
@@ -405,7 +405,7 @@ module FileServer = struct
         ~decode_pb_req:decode_pb_file_path
         () : _ Server.rpc)
     
-    let _rpc_upload_file : (file_chunk,stream,file_crc,unary) Server.rpc = 
+    let upload_file : (file_chunk,stream,file_crc,unary) Server.rpc = 
       (Server.mk_rpc ~name:"upload_file"
         ~req_mode:Server.Stream
         ~res_mode:Server.Unary
@@ -415,7 +415,7 @@ module FileServer = struct
         ~decode_pb_req:decode_pb_file_chunk
         () : _ Server.rpc)
     
-    let _rpc_download_file : (file_path,unary,file_chunk,stream) Server.rpc = 
+    let download_file : (file_path,unary,file_chunk,stream) Server.rpc = 
       (Server.mk_rpc ~name:"download_file"
         ~req_mode:Server.Unary
         ~res_mode:Server.Stream
@@ -425,7 +425,7 @@ module FileServer = struct
         ~decode_pb_req:decode_pb_file_path
         () : _ Server.rpc)
     
-    let _rpc_ping_pong : (ping,stream,pong,stream) Server.rpc = 
+    let ping_pong : (ping,stream,pong,stream) Server.rpc = 
       (Server.mk_rpc ~name:"ping_pong"
         ~req_mode:Server.Stream
         ~res_mode:Server.Stream
@@ -436,19 +436,19 @@ module FileServer = struct
         () : _ Server.rpc)
     
     let make
-      ~touch_file
-      ~upload_file
-      ~download_file
-      ~ping_pong
+      ~touch_file:__handler__touch_file
+      ~upload_file:__handler__upload_file
+      ~download_file:__handler__download_file
+      ~ping_pong:__handler__ping_pong
       () : _ Server.t =
       { Server.
         service_name="FileServer";
         package=[];
         handlers=[
-           (touch_file _rpc_touch_file);
-           (upload_file _rpc_upload_file);
-           (download_file _rpc_download_file);
-           (ping_pong _rpc_ping_pong);
+           (__handler__touch_file touch_file);
+           (__handler__upload_file upload_file);
+           (__handler__download_file download_file);
+           (__handler__ping_pong ping_pong);
         ];
       }
   end

--- a/src/examples/file_server.mli.expected
+++ b/src/examples/file_server.mli.expected
@@ -191,5 +191,15 @@ module FileServer : sig
       download_file:((file_path, unary, file_chunk, stream) Server.rpc -> 'handler) ->
       ping_pong:((ping, stream, pong, stream) Server.rpc -> 'handler) ->
       unit -> 'handler Pbrt_services.Server.t
+    
+    (** The individual server stubs are only exposed for advanced users. Casual users should prefer accessing them through {!make}. *)
+    
+    val touch_file : (file_path,unary,empty,unary) Server.rpc
+    
+    val upload_file : (file_chunk,stream,file_crc,unary) Server.rpc
+    
+    val download_file : (file_path,unary,file_chunk,stream) Server.rpc
+    
+    val ping_pong : (ping,stream,pong,stream) Server.rpc
   end
 end


### PR DESCRIPTION
In this PR, I propose that the generated service interface exposes the
individual RPC endpoints currently hidden. Here's an example of the change this
PR would make to a generated service:

```diff
@|-1,9 +1,19 ============================================================
 |  module Server : sig
 |    (** Produce a server implementation from handlers *)
 |    val make : 
 |      get:((key, unary, value_or_error, unary) Server.rpc -> 'handler) ->
 |      set:((keyval_pair, unary, unit_, unary) Server.rpc -> 'handler) ->
 |      delete:((key, unary, unit_or_error, unary) Server.rpc -> 'handler) ->
 |      listKeys:((unit_, unary, keys, unary) Server.rpc -> 'handler) ->
 |      unit -> 'handler Pbrt_services.Server.t
+|    
+|    (** The individual server stubs are only exposed for advanced users. Casual users should prefer accessing them through {!make}. *)
+|    
+|    val get : (key,unary,value_or_error,unary) Server.rpc
+|    
+|    val set : (keyval_pair,unary,unit_,unary) Server.rpc
+|    
+|    val delete : (key,unary,unit_or_error,unary) Server.rpc
+|    
+|    val listKeys : (unit_,unary,keys,unary) Server.rpc
 |  end
```

This idea originated from our discussion in #224 

For a motivating example for this change, you can have a look at [this pull request](https://github.com/mbarbin/eio-rpc/pull/3) from a personal project.

 - [x] At present, I've maintained the "rpc_" prefix for names (e.g., "rpc_get"
  from the above example). However, I'm considering the potential for more
  consistency by using identical names for the client and server RPCs. Would
  there be any drawbacks to renaming the server endpoint to remove the "rpc_"
  prefix? Edit: now renamed to remove the prefix
- [x] To be rebased once #231 is merged

Thank you for your time and consideration!
