### PR TITLE
Expect tests for generated code in examples/

### DIFF
--- a/src/examples/calculator.ml.expected
+++ b/src/examples/calculator.ml.expected
@@ -1,0 +1,424 @@
+[@@@ocaml.warning "-27-30-39"]
+
+type div_by_zero = unit
+
+type i32 = {
+  value : int32;
+}
+
+type add_req = {
+  a : int32;
+  b : int32;
+}
+
+type add_all_req = {
+  ints : int32 list;
+}
+
+type empty = unit
+
+let rec default_div_by_zero = ()
+
+let rec default_i32 
+  ?value:((value:int32) = 0l)
+  () : i32  = {
+  value;
+}
+
+let rec default_add_req 
+  ?a:((a:int32) = 0l)
+  ?b:((b:int32) = 0l)
+  () : add_req  = {
+  a;
+  b;
+}
+
+let rec default_add_all_req 
+  ?ints:((ints:int32 list) = [])
+  () : add_all_req  = {
+  ints;
+}
+
+let rec default_empty = ()
+
+type i32_mutable = {
+  mutable value : int32;
+}
+
+let default_i32_mutable () : i32_mutable = {
+  value = 0l;
+}
+
+type add_req_mutable = {
+  mutable a : int32;
+  mutable b : int32;
+}
+
+let default_add_req_mutable () : add_req_mutable = {
+  a = 0l;
+  b = 0l;
+}
+
+type add_all_req_mutable = {
+  mutable ints : int32 list;
+}
+
+let default_add_all_req_mutable () : add_all_req_mutable = {
+  ints = [];
+}
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Formatters} *)
+
+let rec pp_div_by_zero fmt (v:div_by_zero) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_unit fmt ()
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_i32 fmt (v:i32) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "value" Pbrt.Pp.pp_int32 fmt v.value;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_add_req fmt (v:add_req) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "a" Pbrt.Pp.pp_int32 fmt v.a;
+    Pbrt.Pp.pp_record_field ~first:false "b" Pbrt.Pp.pp_int32 fmt v.b;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_add_all_req fmt (v:add_all_req) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "ints" (Pbrt.Pp.pp_list Pbrt.Pp.pp_int32) fmt v.ints;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_empty fmt (v:empty) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_unit fmt ()
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Protobuf Encoding} *)
+
+let rec encode_pb_div_by_zero (v:div_by_zero) encoder = 
+()
+
+let rec encode_pb_i32 (v:i32) encoder = 
+  Pbrt.Encoder.int32_as_varint v.value encoder;
+  Pbrt.Encoder.key 0 Pbrt.Varint encoder; 
+  ()
+
+let rec encode_pb_add_req (v:add_req) encoder = 
+  Pbrt.Encoder.int32_as_varint v.a encoder;
+  Pbrt.Encoder.key 1 Pbrt.Varint encoder; 
+  Pbrt.Encoder.int32_as_varint v.b encoder;
+  Pbrt.Encoder.key 2 Pbrt.Varint encoder; 
+  ()
+
+let rec encode_pb_add_all_req (v:add_all_req) encoder = 
+  Pbrt.Encoder.nested (fun lst encoder ->
+    Pbrt.List_util.rev_iter_with (fun x encoder -> 
+      Pbrt.Encoder.int32_as_varint x encoder;
+    ) lst encoder;
+  ) v.ints encoder;
+  Pbrt.Encoder.key 1 Pbrt.Bytes encoder; 
+  ()
+
+let rec encode_pb_empty (v:empty) encoder = 
+()
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Protobuf Decoding} *)
+
+let rec decode_pb_div_by_zero d =
+  match Pbrt.Decoder.key d with
+  | None -> ();
+  | Some (_, pk) -> 
+    Pbrt.Decoder.unexpected_payload "Unexpected fields in empty message(div_by_zero)" pk
+
+let rec decode_pb_i32 d =
+  let v = default_i32_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+    ); continue__ := false
+    | Some (0, Pbrt.Varint) -> begin
+      v.value <- Pbrt.Decoder.int32_as_varint d;
+    end
+    | Some (0, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(i32), field(0)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    value = v.value;
+  } : i32)
+
+let rec decode_pb_add_req d =
+  let v = default_add_req_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+    ); continue__ := false
+    | Some (1, Pbrt.Varint) -> begin
+      v.a <- Pbrt.Decoder.int32_as_varint d;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(add_req), field(1)" pk
+    | Some (2, Pbrt.Varint) -> begin
+      v.b <- Pbrt.Decoder.int32_as_varint d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(add_req), field(2)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    a = v.a;
+    b = v.b;
+  } : add_req)
+
+let rec decode_pb_add_all_req d =
+  let v = default_add_all_req_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.ints <- List.rev v.ints;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.ints <- Pbrt.Decoder.packed_fold (fun l d -> (Pbrt.Decoder.int32_as_varint d)::l) [] d;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(add_all_req), field(1)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    ints = v.ints;
+  } : add_all_req)
+
+let rec decode_pb_empty d =
+  match Pbrt.Decoder.key d with
+  | None -> ();
+  | Some (_, pk) -> 
+    Pbrt.Decoder.unexpected_payload "Unexpected fields in empty message(empty)" pk
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Protobuf YoJson Encoding} *)
+
+let rec encode_json_div_by_zero (v:div_by_zero) = 
+Pbrt_yojson.make_unit v
+
+let rec encode_json_i32 (v:i32) = 
+  let assoc = [] in 
+  let assoc = ("value", Pbrt_yojson.make_int (Int32.to_int v.value)) :: assoc in
+  `Assoc assoc
+
+let rec encode_json_add_req (v:add_req) = 
+  let assoc = [] in 
+  let assoc = ("a", Pbrt_yojson.make_int (Int32.to_int v.a)) :: assoc in
+  let assoc = ("b", Pbrt_yojson.make_int (Int32.to_int v.b)) :: assoc in
+  `Assoc assoc
+
+let rec encode_json_add_all_req (v:add_all_req) = 
+  let assoc = [] in 
+  let assoc =
+    let l = v.ints |> List.map Int32.to_int |> List.map Pbrt_yojson.make_int in 
+    ("ints", `List l) :: assoc 
+  in
+  `Assoc assoc
+
+let rec encode_json_empty (v:empty) = 
+Pbrt_yojson.make_unit v
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 JSON Decoding} *)
+
+let rec decode_json_div_by_zero d =
+Pbrt_yojson.unit d "div_by_zero" "empty record"
+
+let rec decode_json_i32 d =
+  let v = default_i32_mutable () in
+  let assoc = match d with
+    | `Assoc assoc -> assoc
+    | _ -> assert(false)
+  in
+  List.iter (function 
+    | ("value", json_value) -> 
+      v.value <- Pbrt_yojson.int32 json_value "i32" "value"
+    
+    | (_, _) -> () (*Unknown fields are ignored*)
+  ) assoc;
+  ({
+    value = v.value;
+  } : i32)
+
+let rec decode_json_add_req d =
+  let v = default_add_req_mutable () in
+  let assoc = match d with
+    | `Assoc assoc -> assoc
+    | _ -> assert(false)
+  in
+  List.iter (function 
+    | ("a", json_value) -> 
+      v.a <- Pbrt_yojson.int32 json_value "add_req" "a"
+    | ("b", json_value) -> 
+      v.b <- Pbrt_yojson.int32 json_value "add_req" "b"
+    
+    | (_, _) -> () (*Unknown fields are ignored*)
+  ) assoc;
+  ({
+    a = v.a;
+    b = v.b;
+  } : add_req)
+
+let rec decode_json_add_all_req d =
+  let v = default_add_all_req_mutable () in
+  let assoc = match d with
+    | `Assoc assoc -> assoc
+    | _ -> assert(false)
+  in
+  List.iter (function 
+    | ("ints", `List l) -> begin
+      v.ints <- List.map (function
+        | json_value -> Pbrt_yojson.int32 json_value "add_all_req" "ints"
+      ) l;
+    end
+    
+    | (_, _) -> () (*Unknown fields are ignored*)
+  ) assoc;
+  ({
+    ints = v.ints;
+  } : add_all_req)
+
+let rec decode_json_empty d =
+Pbrt_yojson.unit d "empty" "empty record"
+
+module Calculator = struct
+  open Pbrt_services.Value_mode
+  module Client = struct
+    open Pbrt_services
+    
+    let add : (add_req, unary, i32, unary) Client.rpc =
+      (Client.mk_rpc 
+        ~package:[]
+        ~service_name:"Calculator" ~rpc_name:"add"
+        ~req_mode:Client.Unary
+        ~res_mode:Client.Unary
+        ~encode_json_req:encode_json_add_req
+        ~encode_pb_req:encode_pb_add_req
+        ~decode_json_res:decode_json_i32
+        ~decode_pb_res:decode_pb_i32
+        () : (add_req, unary, i32, unary) Client.rpc)
+    open Pbrt_services
+    
+    let add_all : (add_all_req, unary, i32, unary) Client.rpc =
+      (Client.mk_rpc 
+        ~package:[]
+        ~service_name:"Calculator" ~rpc_name:"add_all"
+        ~req_mode:Client.Unary
+        ~res_mode:Client.Unary
+        ~encode_json_req:encode_json_add_all_req
+        ~encode_pb_req:encode_pb_add_all_req
+        ~decode_json_res:decode_json_i32
+        ~decode_pb_res:decode_pb_i32
+        () : (add_all_req, unary, i32, unary) Client.rpc)
+    open Pbrt_services
+    
+    let ping : (empty, unary, empty, unary) Client.rpc =
+      (Client.mk_rpc 
+        ~package:[]
+        ~service_name:"Calculator" ~rpc_name:"ping"
+        ~req_mode:Client.Unary
+        ~res_mode:Client.Unary
+        ~encode_json_req:encode_json_empty
+        ~encode_pb_req:encode_pb_empty
+        ~decode_json_res:decode_json_empty
+        ~decode_pb_res:decode_pb_empty
+        () : (empty, unary, empty, unary) Client.rpc)
+    open Pbrt_services
+    
+    let get_pings : (empty, unary, i32, unary) Client.rpc =
+      (Client.mk_rpc 
+        ~package:[]
+        ~service_name:"Calculator" ~rpc_name:"get_pings"
+        ~req_mode:Client.Unary
+        ~res_mode:Client.Unary
+        ~encode_json_req:encode_json_empty
+        ~encode_pb_req:encode_pb_empty
+        ~decode_json_res:decode_json_i32
+        ~decode_pb_res:decode_pb_i32
+        () : (empty, unary, i32, unary) Client.rpc)
+  end
+  
+  module Server = struct
+    open Pbrt_services
+    
+    let _rpc_add : (add_req,unary,i32,unary) Server.rpc = 
+      (Server.mk_rpc ~name:"add"
+        ~req_mode:Server.Unary
+        ~res_mode:Server.Unary
+        ~encode_json_res:encode_json_i32
+        ~encode_pb_res:encode_pb_i32
+        ~decode_json_req:decode_json_add_req
+        ~decode_pb_req:decode_pb_add_req
+        () : _ Server.rpc)
+    
+    let _rpc_add_all : (add_all_req,unary,i32,unary) Server.rpc = 
+      (Server.mk_rpc ~name:"add_all"
+        ~req_mode:Server.Unary
+        ~res_mode:Server.Unary
+        ~encode_json_res:encode_json_i32
+        ~encode_pb_res:encode_pb_i32
+        ~decode_json_req:decode_json_add_all_req
+        ~decode_pb_req:decode_pb_add_all_req
+        () : _ Server.rpc)
+    
+    let _rpc_ping : (empty,unary,empty,unary) Server.rpc = 
+      (Server.mk_rpc ~name:"ping"
+        ~req_mode:Server.Unary
+        ~res_mode:Server.Unary
+        ~encode_json_res:encode_json_empty
+        ~encode_pb_res:encode_pb_empty
+        ~decode_json_req:decode_json_empty
+        ~decode_pb_req:decode_pb_empty
+        () : _ Server.rpc)
+    
+    let _rpc_get_pings : (empty,unary,i32,unary) Server.rpc = 
+      (Server.mk_rpc ~name:"get_pings"
+        ~req_mode:Server.Unary
+        ~res_mode:Server.Unary
+        ~encode_json_res:encode_json_i32
+        ~encode_pb_res:encode_pb_i32
+        ~decode_json_req:decode_json_empty
+        ~decode_pb_req:decode_pb_empty
+        () : _ Server.rpc)
+    
+    let make
+      ~add
+      ~add_all
+      ~ping
+      ~get_pings
+      () : _ Server.t =
+      { Server.
+        service_name="Calculator";
+        package=[];
+        handlers=[
+           (add _rpc_add);
+           (add_all _rpc_add_all);
+           (ping _rpc_ping);
+           (get_pings _rpc_get_pings);
+        ];
+      }
+  end
+  
+end

--- a/src/examples/calculator.mli.expected
+++ b/src/examples/calculator.mli.expected
@@ -1,0 +1,173 @@
+
+(** Code for calculator.proto *)
+
+(* generated from "calculator.proto", do not edit *)
+
+
+
+(** {2 Types} *)
+
+type div_by_zero = unit
+
+type i32 = {
+  value : int32;
+}
+
+type add_req = {
+  a : int32;
+  b : int32;
+}
+
+type add_all_req = {
+  ints : int32 list;
+}
+
+type empty = unit
+
+
+(** {2 Basic values} *)
+
+val default_div_by_zero : unit
+(** [default_div_by_zero ()] is the default value for type [div_by_zero] *)
+
+val default_i32 : 
+  ?value:int32 ->
+  unit ->
+  i32
+(** [default_i32 ()] is the default value for type [i32] *)
+
+val default_add_req : 
+  ?a:int32 ->
+  ?b:int32 ->
+  unit ->
+  add_req
+(** [default_add_req ()] is the default value for type [add_req] *)
+
+val default_add_all_req : 
+  ?ints:int32 list ->
+  unit ->
+  add_all_req
+(** [default_add_all_req ()] is the default value for type [add_all_req] *)
+
+val default_empty : unit
+(** [default_empty ()] is the default value for type [empty] *)
+
+
+(** {2 Formatters} *)
+
+val pp_div_by_zero : Format.formatter -> div_by_zero -> unit 
+(** [pp_div_by_zero v] formats v *)
+
+val pp_i32 : Format.formatter -> i32 -> unit 
+(** [pp_i32 v] formats v *)
+
+val pp_add_req : Format.formatter -> add_req -> unit 
+(** [pp_add_req v] formats v *)
+
+val pp_add_all_req : Format.formatter -> add_all_req -> unit 
+(** [pp_add_all_req v] formats v *)
+
+val pp_empty : Format.formatter -> empty -> unit 
+(** [pp_empty v] formats v *)
+
+
+(** {2 Protobuf Encoding} *)
+
+val encode_pb_div_by_zero : div_by_zero -> Pbrt.Encoder.t -> unit
+(** [encode_pb_div_by_zero v encoder] encodes [v] with the given [encoder] *)
+
+val encode_pb_i32 : i32 -> Pbrt.Encoder.t -> unit
+(** [encode_pb_i32 v encoder] encodes [v] with the given [encoder] *)
+
+val encode_pb_add_req : add_req -> Pbrt.Encoder.t -> unit
+(** [encode_pb_add_req v encoder] encodes [v] with the given [encoder] *)
+
+val encode_pb_add_all_req : add_all_req -> Pbrt.Encoder.t -> unit
+(** [encode_pb_add_all_req v encoder] encodes [v] with the given [encoder] *)
+
+val encode_pb_empty : empty -> Pbrt.Encoder.t -> unit
+(** [encode_pb_empty v encoder] encodes [v] with the given [encoder] *)
+
+
+(** {2 Protobuf Decoding} *)
+
+val decode_pb_div_by_zero : Pbrt.Decoder.t -> div_by_zero
+(** [decode_pb_div_by_zero decoder] decodes a [div_by_zero] binary value from [decoder] *)
+
+val decode_pb_i32 : Pbrt.Decoder.t -> i32
+(** [decode_pb_i32 decoder] decodes a [i32] binary value from [decoder] *)
+
+val decode_pb_add_req : Pbrt.Decoder.t -> add_req
+(** [decode_pb_add_req decoder] decodes a [add_req] binary value from [decoder] *)
+
+val decode_pb_add_all_req : Pbrt.Decoder.t -> add_all_req
+(** [decode_pb_add_all_req decoder] decodes a [add_all_req] binary value from [decoder] *)
+
+val decode_pb_empty : Pbrt.Decoder.t -> empty
+(** [decode_pb_empty decoder] decodes a [empty] binary value from [decoder] *)
+
+
+(** {2 Protobuf YoJson Encoding} *)
+
+val encode_json_div_by_zero : div_by_zero -> Yojson.Basic.t
+(** [encode_json_div_by_zero v encoder] encodes [v] to to json *)
+
+val encode_json_i32 : i32 -> Yojson.Basic.t
+(** [encode_json_i32 v encoder] encodes [v] to to json *)
+
+val encode_json_add_req : add_req -> Yojson.Basic.t
+(** [encode_json_add_req v encoder] encodes [v] to to json *)
+
+val encode_json_add_all_req : add_all_req -> Yojson.Basic.t
+(** [encode_json_add_all_req v encoder] encodes [v] to to json *)
+
+val encode_json_empty : empty -> Yojson.Basic.t
+(** [encode_json_empty v encoder] encodes [v] to to json *)
+
+
+(** {2 JSON Decoding} *)
+
+val decode_json_div_by_zero : Yojson.Basic.t -> div_by_zero
+(** [decode_json_div_by_zero decoder] decodes a [div_by_zero] value from [decoder] *)
+
+val decode_json_i32 : Yojson.Basic.t -> i32
+(** [decode_json_i32 decoder] decodes a [i32] value from [decoder] *)
+
+val decode_json_add_req : Yojson.Basic.t -> add_req
+(** [decode_json_add_req decoder] decodes a [add_req] value from [decoder] *)
+
+val decode_json_add_all_req : Yojson.Basic.t -> add_all_req
+(** [decode_json_add_all_req decoder] decodes a [add_all_req] value from [decoder] *)
+
+val decode_json_empty : Yojson.Basic.t -> empty
+(** [decode_json_empty decoder] decodes a [empty] value from [decoder] *)
+
+
+(** {2 Services} *)
+
+(** Calculator service *)
+module Calculator : sig
+  open Pbrt_services
+  open Pbrt_services.Value_mode
+  
+  module Client : sig
+    
+    val add : (add_req, unary, i32, unary) Client.rpc
+    
+    val add_all : (add_all_req, unary, i32, unary) Client.rpc
+    
+    val ping : (empty, unary, empty, unary) Client.rpc
+    
+    val get_pings : (empty, unary, i32, unary) Client.rpc
+  end
+  
+  module Server : sig
+    (** Produce a server implementation from handlers *)
+    val make : 
+      add:((add_req, unary, i32, unary) Server.rpc -> 'handler) ->
+      add_all:((add_all_req, unary, i32, unary) Server.rpc -> 'handler) ->
+      ping:((empty, unary, empty, unary) Server.rpc -> 'handler) ->
+      get_pings:((empty, unary, i32, unary) Server.rpc -> 'handler) ->
+      unit -> 'handler Pbrt_services.Server.t
+  end
+end

--- a/src/examples/dune
+++ b/src/examples/dune
@@ -4,6 +4,16 @@
  (action
   (run ocaml-protoc --binary --pp --ml_out ./ %{deps})))
 
+(rule
+ (alias runtest)
+ (action
+  (diff example01.ml.expected example01.ml)))
+
+(rule
+ (alias runtest)
+ (action
+  (diff example01.mli.expected example01.mli)))
+
 (test
  (name example01)
  (modules t_example01 example01)
@@ -15,6 +25,16 @@
  (deps example03.proto)
  (action
   (run ocaml-protoc --pp --ml_out ./ %{deps})))
+
+(rule
+ (alias runtest)
+ (action
+  (diff example03.ml.expected example03.ml)))
+
+(rule
+ (alias runtest)
+ (action
+  (diff example03.mli.expected example03.mli)))
 
 (test
  (name example03)
@@ -28,6 +48,16 @@
  (action
   (run ocaml-protoc --pp --ml_out ./ %{deps})))
 
+(rule
+ (alias runtest)
+ (action
+  (diff example04.ml.expected example04.ml)))
+
+(rule
+ (alias runtest)
+ (action
+  (diff example04.mli.expected example04.mli)))
+
 (test
  (name example04)
  (modules t_example04 example04)
@@ -39,6 +69,16 @@
  (deps example05.proto)
  (action
   (run ocaml-protoc --binary --pp --ml_out ./ %{deps})))
+
+(rule
+ (alias runtest)
+ (action
+  (diff example05.ml.expected example05.ml)))
+
+(rule
+ (alias runtest)
+ (action
+  (diff example05.mli.expected example05.mli)))
 
 (test
  (name example05)
@@ -52,6 +92,16 @@
  (action
   (run ocaml-protoc --binary --pp --yojson --services --ml_out ./ %{deps})))
 
+(rule
+ (alias runtest)
+ (action
+  (diff calculator.ml.expected calculator.ml)))
+
+(rule
+ (alias runtest)
+ (action
+  (diff calculator.mli.expected calculator.mli)))
+
 (test
  (name calculator)
  (modules t_calculator calculator)
@@ -64,6 +114,16 @@
  (action
   (run ocaml-protoc --binary --pp --yojson --services --ml_out ./ %{deps})))
 
+(rule
+ (alias runtest)
+ (action
+  (diff file_server.ml.expected file_server.ml)))
+
+(rule
+ (alias runtest)
+ (action
+  (diff file_server.mli.expected file_server.mli)))
+
 (test
  (name file_server)
  (modules file_server) ; just check that it compiles
@@ -75,6 +135,16 @@
  (deps orgchart.proto)
  (action
   (run ocaml-protoc --pp --binary --ml_out ./ %{deps})))
+
+(rule
+ (alias runtest)
+ (action
+  (diff orgchart.ml.expected orgchart.ml)))
+
+(rule
+ (alias runtest)
+ (action
+  (diff orgchart.mli.expected orgchart.mli)))
 
 (test
  (name orgchart_ml)

--- a/src/examples/example01.ml.expected
+++ b/src/examples/example01.ml.expected
@@ -1,0 +1,105 @@
+[@@@ocaml.warning "-27-30-39"]
+
+type person = {
+  name : string;
+  id : int32;
+  email : string;
+  phone : string list;
+}
+
+let rec default_person 
+  ?name:((name:string) = "")
+  ?id:((id:int32) = 0l)
+  ?email:((email:string) = "")
+  ?phone:((phone:string list) = [])
+  () : person  = {
+  name;
+  id;
+  email;
+  phone;
+}
+
+type person_mutable = {
+  mutable name : string;
+  mutable id : int32;
+  mutable email : string;
+  mutable phone : string list;
+}
+
+let default_person_mutable () : person_mutable = {
+  name = "";
+  id = 0l;
+  email = "";
+  phone = [];
+}
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Formatters} *)
+
+let rec pp_person fmt (v:person) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "name" Pbrt.Pp.pp_string fmt v.name;
+    Pbrt.Pp.pp_record_field ~first:false "id" Pbrt.Pp.pp_int32 fmt v.id;
+    Pbrt.Pp.pp_record_field ~first:false "email" Pbrt.Pp.pp_string fmt v.email;
+    Pbrt.Pp.pp_record_field ~first:false "phone" (Pbrt.Pp.pp_list Pbrt.Pp.pp_string) fmt v.phone;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Protobuf Encoding} *)
+
+let rec encode_pb_person (v:person) encoder = 
+  Pbrt.Encoder.string v.name encoder;
+  Pbrt.Encoder.key 1 Pbrt.Bytes encoder; 
+  Pbrt.Encoder.int32_as_varint v.id encoder;
+  Pbrt.Encoder.key 2 Pbrt.Varint encoder; 
+  Pbrt.Encoder.string v.email encoder;
+  Pbrt.Encoder.key 3 Pbrt.Bytes encoder; 
+  Pbrt.List_util.rev_iter_with (fun x encoder -> 
+    Pbrt.Encoder.string x encoder;
+    Pbrt.Encoder.key 4 Pbrt.Bytes encoder; 
+  ) v.phone encoder;
+  ()
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Protobuf Decoding} *)
+
+let rec decode_pb_person d =
+  let v = default_person_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.phone <- List.rev v.phone;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.name <- Pbrt.Decoder.string d;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(person), field(1)" pk
+    | Some (2, Pbrt.Varint) -> begin
+      v.id <- Pbrt.Decoder.int32_as_varint d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(person), field(2)" pk
+    | Some (3, Pbrt.Bytes) -> begin
+      v.email <- Pbrt.Decoder.string d;
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(person), field(3)" pk
+    | Some (4, Pbrt.Bytes) -> begin
+      v.phone <- (Pbrt.Decoder.string d) :: v.phone;
+    end
+    | Some (4, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(person), field(4)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    name = v.name;
+    id = v.id;
+    email = v.email;
+    phone = v.phone;
+  } : person)

--- a/src/examples/example01.mli.expected
+++ b/src/examples/example01.mli.expected
@@ -1,0 +1,45 @@
+
+(** Code for example01.proto *)
+
+(* generated from "example01.proto", do not edit *)
+
+
+
+(** {2 Types} *)
+
+type person = {
+  name : string;
+  id : int32;
+  email : string;
+  phone : string list;
+}
+
+
+(** {2 Basic values} *)
+
+val default_person : 
+  ?name:string ->
+  ?id:int32 ->
+  ?email:string ->
+  ?phone:string list ->
+  unit ->
+  person
+(** [default_person ()] is the default value for type [person] *)
+
+
+(** {2 Formatters} *)
+
+val pp_person : Format.formatter -> person -> unit 
+(** [pp_person v] formats v *)
+
+
+(** {2 Protobuf Encoding} *)
+
+val encode_pb_person : person -> Pbrt.Encoder.t -> unit
+(** [encode_pb_person v encoder] encodes [v] with the given [encoder] *)
+
+
+(** {2 Protobuf Decoding} *)
+
+val decode_pb_person : Pbrt.Decoder.t -> person
+(** [decode_pb_person decoder] decodes a [person] binary value from [decoder] *)

--- a/src/examples/example03.ml.expected
+++ b/src/examples/example03.ml.expected
@@ -1,0 +1,26 @@
+[@@@ocaml.warning "-27-30-39"]
+
+type string_some_none = unit
+
+type string_some =
+  | None
+  | Some of string
+
+let rec default_string_some_none = ()
+
+let rec default_string_some (): string_some = None
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Formatters} *)
+
+let rec pp_string_some_none fmt (v:string_some_none) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_unit fmt ()
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_string_some fmt (v:string_some) =
+  match v with
+  | None  -> Format.fprintf fmt "None"
+  | Some x -> Format.fprintf fmt "@[<hv2>Some(@,%a)@]" Pbrt.Pp.pp_string x

--- a/src/examples/example03.mli.expected
+++ b/src/examples/example03.mli.expected
@@ -1,0 +1,32 @@
+
+(** Code for example03.proto *)
+
+(* generated from "example03.proto", do not edit *)
+
+
+
+(** {2 Types} *)
+
+type string_some_none = unit
+
+type string_some =
+  | None
+  | Some of string
+
+
+(** {2 Basic values} *)
+
+val default_string_some_none : unit
+(** [default_string_some_none ()] is the default value for type [string_some_none] *)
+
+val default_string_some : unit -> string_some
+(** [default_string_some ()] is the default value for type [string_some] *)
+
+
+(** {2 Formatters} *)
+
+val pp_string_some_none : Format.formatter -> string_some_none -> unit 
+(** [pp_string_some_none v] formats v *)
+
+val pp_string_some : Format.formatter -> string_some -> unit 
+(** [pp_string_some v] formats v *)

--- a/src/examples/example04.ml.expected
+++ b/src/examples/example04.ml.expected
@@ -1,0 +1,46 @@
+[@@@ocaml.warning "-27-30-39"]
+
+type int_list_nil = unit
+
+type int_list_cons = {
+  value : int;
+  next : int_list;
+}
+
+and int_list =
+  | Cons of int_list_cons
+  | Nil
+
+let rec default_int_list_nil = ()
+
+let rec default_int_list_cons 
+  ?value:((value:int) = 0)
+  ?next:((next:int_list) = default_int_list ())
+  () : int_list_cons  = {
+  value;
+  next;
+}
+
+and default_int_list () : int_list = Cons (default_int_list_cons ())
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Formatters} *)
+
+let rec pp_int_list_nil fmt (v:int_list_nil) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_unit fmt ()
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_int_list_cons fmt (v:int_list_cons) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "value" Pbrt.Pp.pp_int fmt v.value;
+    Pbrt.Pp.pp_record_field ~first:false "next" pp_int_list fmt v.next;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+and pp_int_list fmt (v:int_list) =
+  match v with
+  | Cons x -> Format.fprintf fmt "@[<hv2>Cons(@,%a)@]" pp_int_list_cons x
+  | Nil  -> Format.fprintf fmt "Nil"

--- a/src/examples/example04.mli.expected
+++ b/src/examples/example04.mli.expected
@@ -1,0 +1,47 @@
+
+(** Code for example04.proto *)
+
+(* generated from "example04.proto", do not edit *)
+
+
+
+(** {2 Types} *)
+
+type int_list_nil = unit
+
+type int_list_cons = {
+  value : int;
+  next : int_list;
+}
+
+and int_list =
+  | Cons of int_list_cons
+  | Nil
+
+
+(** {2 Basic values} *)
+
+val default_int_list_nil : unit
+(** [default_int_list_nil ()] is the default value for type [int_list_nil] *)
+
+val default_int_list_cons : 
+  ?value:int ->
+  ?next:int_list ->
+  unit ->
+  int_list_cons
+(** [default_int_list_cons ()] is the default value for type [int_list_cons] *)
+
+val default_int_list : unit -> int_list
+(** [default_int_list ()] is the default value for type [int_list] *)
+
+
+(** {2 Formatters} *)
+
+val pp_int_list_nil : Format.formatter -> int_list_nil -> unit 
+(** [pp_int_list_nil v] formats v *)
+
+val pp_int_list_cons : Format.formatter -> int_list_cons -> unit 
+(** [pp_int_list_cons v] formats v *)
+
+val pp_int_list : Format.formatter -> int_list -> unit 
+(** [pp_int_list v] formats v *)

--- a/src/examples/example05.ml.expected
+++ b/src/examples/example05.ml.expected
@@ -1,0 +1,138 @@
+[@@@ocaml.warning "-27-30-39"]
+
+type person = {
+  name : string;
+  id : int32;
+  email : string option;
+  phone : string list;
+  details : (string, string) Hashtbl.t;
+}
+
+let rec default_person 
+  ?name:((name:string) = "")
+  ?id:((id:int32) = 0l)
+  ?email:((email:string option) = None)
+  ?phone:((phone:string list) = [])
+  ?details:((details:(string, string) Hashtbl.t) = Hashtbl.create 128)
+  () : person  = {
+  name;
+  id;
+  email;
+  phone;
+  details;
+}
+
+type person_mutable = {
+  mutable name : string;
+  mutable id : int32;
+  mutable email : string option;
+  mutable phone : string list;
+  details : (string, string) Hashtbl.t;
+}
+
+let default_person_mutable () : person_mutable = {
+  name = "";
+  id = 0l;
+  email = None;
+  phone = [];
+  details = Hashtbl.create 128;
+}
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Formatters} *)
+
+let rec pp_person fmt (v:person) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "name" Pbrt.Pp.pp_string fmt v.name;
+    Pbrt.Pp.pp_record_field ~first:false "id" Pbrt.Pp.pp_int32 fmt v.id;
+    Pbrt.Pp.pp_record_field ~first:false "email" (Pbrt.Pp.pp_option Pbrt.Pp.pp_string) fmt v.email;
+    Pbrt.Pp.pp_record_field ~first:false "phone" (Pbrt.Pp.pp_list Pbrt.Pp.pp_string) fmt v.phone;
+    Pbrt.Pp.pp_record_field ~first:false "details" (Pbrt.Pp.pp_hastable Pbrt.Pp.pp_string Pbrt.Pp.pp_string) fmt v.details;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Protobuf Encoding} *)
+
+let rec encode_pb_person (v:person) encoder = 
+  Pbrt.Encoder.string v.name encoder;
+  Pbrt.Encoder.key 1 Pbrt.Bytes encoder; 
+  Pbrt.Encoder.int32_as_varint v.id encoder;
+  Pbrt.Encoder.key 2 Pbrt.Varint encoder; 
+  begin match v.email with
+  | Some x -> 
+    Pbrt.Encoder.string x encoder;
+    Pbrt.Encoder.key 3 Pbrt.Bytes encoder; 
+  | None -> ();
+  end;
+  Pbrt.List_util.rev_iter_with (fun x encoder -> 
+    Pbrt.Encoder.string x encoder;
+    Pbrt.Encoder.key 4 Pbrt.Bytes encoder; 
+  ) v.phone encoder;
+  let encode_key = Pbrt.Encoder.string in
+  let encode_value = (fun x encoder ->
+    Pbrt.Encoder.string x encoder;
+  ) in
+  Hashtbl.iter (fun k v ->
+    let map_entry = (k, Pbrt.Bytes), (v, Pbrt.Bytes) in
+    Pbrt.Encoder.map_entry ~encode_key ~encode_value map_entry encoder;
+    Pbrt.Encoder.key 5 Pbrt.Bytes encoder; 
+  ) v.details;
+  ()
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Protobuf Decoding} *)
+
+let rec decode_pb_person d =
+  let v = default_person_mutable () in
+  let continue__= ref true in
+  let id_is_set = ref false in
+  let name_is_set = ref false in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.phone <- List.rev v.phone;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.name <- Pbrt.Decoder.string d; name_is_set := true;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(person), field(1)" pk
+    | Some (2, Pbrt.Varint) -> begin
+      v.id <- Pbrt.Decoder.int32_as_varint d; id_is_set := true;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(person), field(2)" pk
+    | Some (3, Pbrt.Bytes) -> begin
+      v.email <- Some (Pbrt.Decoder.string d);
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(person), field(3)" pk
+    | Some (4, Pbrt.Bytes) -> begin
+      v.phone <- (Pbrt.Decoder.string d) :: v.phone;
+    end
+    | Some (4, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(person), field(4)" pk
+    | Some (5, Pbrt.Bytes) -> begin
+      let decode_value = (fun d ->
+        Pbrt.Decoder.string d
+      ) in
+      let a, b = (Pbrt.Decoder.map_entry d ~decode_key:Pbrt.Decoder.string ~decode_value) in
+      Hashtbl.add v.details a b;
+    end
+    | Some (5, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(person), field(5)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  begin if not !id_is_set then Pbrt.Decoder.missing_field "id" end;
+  begin if not !name_is_set then Pbrt.Decoder.missing_field "name" end;
+  ({
+    name = v.name;
+    id = v.id;
+    email = v.email;
+    phone = v.phone;
+    details = v.details;
+  } : person)

--- a/src/examples/example05.mli.expected
+++ b/src/examples/example05.mli.expected
@@ -1,0 +1,47 @@
+
+(** Code for example05.proto *)
+
+(* generated from "example05.proto", do not edit *)
+
+
+
+(** {2 Types} *)
+
+type person = {
+  name : string;
+  id : int32;
+  email : string option;
+  phone : string list;
+  details : (string, string) Hashtbl.t;
+}
+
+
+(** {2 Basic values} *)
+
+val default_person : 
+  ?name:string ->
+  ?id:int32 ->
+  ?email:string option ->
+  ?phone:string list ->
+  ?details:(string, string) Hashtbl.t ->
+  unit ->
+  person
+(** [default_person ()] is the default value for type [person] *)
+
+
+(** {2 Formatters} *)
+
+val pp_person : Format.formatter -> person -> unit 
+(** [pp_person v] formats v *)
+
+
+(** {2 Protobuf Encoding} *)
+
+val encode_pb_person : person -> Pbrt.Encoder.t -> unit
+(** [encode_pb_person v encoder] encodes [v] with the given [encoder] *)
+
+
+(** {2 Protobuf Decoding} *)
+
+val decode_pb_person : Pbrt.Decoder.t -> person
+(** [decode_pb_person decoder] decodes a [person] binary value from [decoder] *)

--- a/src/examples/file_server.ml.expected
+++ b/src/examples/file_server.ml.expected
@@ -1,0 +1,456 @@
+[@@@ocaml.warning "-27-30-39"]
+
+type file_chunk = {
+  path : string;
+  data : bytes;
+  crc : int32;
+}
+
+type file_path = {
+  path : string;
+}
+
+type file_crc = {
+  crc : int32;
+}
+
+type empty = unit
+
+type ping = unit
+
+type pong = unit
+
+let rec default_file_chunk 
+  ?path:((path:string) = "")
+  ?data:((data:bytes) = Bytes.create 0)
+  ?crc:((crc:int32) = 0l)
+  () : file_chunk  = {
+  path;
+  data;
+  crc;
+}
+
+let rec default_file_path 
+  ?path:((path:string) = "")
+  () : file_path  = {
+  path;
+}
+
+let rec default_file_crc 
+  ?crc:((crc:int32) = 0l)
+  () : file_crc  = {
+  crc;
+}
+
+let rec default_empty = ()
+
+let rec default_ping = ()
+
+let rec default_pong = ()
+
+type file_chunk_mutable = {
+  mutable path : string;
+  mutable data : bytes;
+  mutable crc : int32;
+}
+
+let default_file_chunk_mutable () : file_chunk_mutable = {
+  path = "";
+  data = Bytes.create 0;
+  crc = 0l;
+}
+
+type file_path_mutable = {
+  mutable path : string;
+}
+
+let default_file_path_mutable () : file_path_mutable = {
+  path = "";
+}
+
+type file_crc_mutable = {
+  mutable crc : int32;
+}
+
+let default_file_crc_mutable () : file_crc_mutable = {
+  crc = 0l;
+}
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Formatters} *)
+
+let rec pp_file_chunk fmt (v:file_chunk) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "path" Pbrt.Pp.pp_string fmt v.path;
+    Pbrt.Pp.pp_record_field ~first:false "data" Pbrt.Pp.pp_bytes fmt v.data;
+    Pbrt.Pp.pp_record_field ~first:false "crc" Pbrt.Pp.pp_int32 fmt v.crc;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_file_path fmt (v:file_path) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "path" Pbrt.Pp.pp_string fmt v.path;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_file_crc fmt (v:file_crc) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "crc" Pbrt.Pp.pp_int32 fmt v.crc;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_empty fmt (v:empty) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_unit fmt ()
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_ping fmt (v:ping) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_unit fmt ()
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_pong fmt (v:pong) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_unit fmt ()
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Protobuf Encoding} *)
+
+let rec encode_pb_file_chunk (v:file_chunk) encoder = 
+  Pbrt.Encoder.string v.path encoder;
+  Pbrt.Encoder.key 1 Pbrt.Bytes encoder; 
+  Pbrt.Encoder.bytes v.data encoder;
+  Pbrt.Encoder.key 2 Pbrt.Bytes encoder; 
+  Pbrt.Encoder.int32_as_varint v.crc encoder;
+  Pbrt.Encoder.key 3 Pbrt.Varint encoder; 
+  ()
+
+let rec encode_pb_file_path (v:file_path) encoder = 
+  Pbrt.Encoder.string v.path encoder;
+  Pbrt.Encoder.key 1 Pbrt.Bytes encoder; 
+  ()
+
+let rec encode_pb_file_crc (v:file_crc) encoder = 
+  Pbrt.Encoder.int32_as_varint v.crc encoder;
+  Pbrt.Encoder.key 1 Pbrt.Varint encoder; 
+  ()
+
+let rec encode_pb_empty (v:empty) encoder = 
+()
+
+let rec encode_pb_ping (v:ping) encoder = 
+()
+
+let rec encode_pb_pong (v:pong) encoder = 
+()
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Protobuf Decoding} *)
+
+let rec decode_pb_file_chunk d =
+  let v = default_file_chunk_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.path <- Pbrt.Decoder.string d;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(file_chunk), field(1)" pk
+    | Some (2, Pbrt.Bytes) -> begin
+      v.data <- Pbrt.Decoder.bytes d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(file_chunk), field(2)" pk
+    | Some (3, Pbrt.Varint) -> begin
+      v.crc <- Pbrt.Decoder.int32_as_varint d;
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(file_chunk), field(3)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    path = v.path;
+    data = v.data;
+    crc = v.crc;
+  } : file_chunk)
+
+let rec decode_pb_file_path d =
+  let v = default_file_path_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.path <- Pbrt.Decoder.string d;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(file_path), field(1)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    path = v.path;
+  } : file_path)
+
+let rec decode_pb_file_crc d =
+  let v = default_file_crc_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+    ); continue__ := false
+    | Some (1, Pbrt.Varint) -> begin
+      v.crc <- Pbrt.Decoder.int32_as_varint d;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(file_crc), field(1)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    crc = v.crc;
+  } : file_crc)
+
+let rec decode_pb_empty d =
+  match Pbrt.Decoder.key d with
+  | None -> ();
+  | Some (_, pk) -> 
+    Pbrt.Decoder.unexpected_payload "Unexpected fields in empty message(empty)" pk
+
+let rec decode_pb_ping d =
+  match Pbrt.Decoder.key d with
+  | None -> ();
+  | Some (_, pk) -> 
+    Pbrt.Decoder.unexpected_payload "Unexpected fields in empty message(ping)" pk
+
+let rec decode_pb_pong d =
+  match Pbrt.Decoder.key d with
+  | None -> ();
+  | Some (_, pk) -> 
+    Pbrt.Decoder.unexpected_payload "Unexpected fields in empty message(pong)" pk
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Protobuf YoJson Encoding} *)
+
+let rec encode_json_file_chunk (v:file_chunk) = 
+  let assoc = [] in 
+  let assoc = ("path", Pbrt_yojson.make_string v.path) :: assoc in
+  let assoc = ("data", Pbrt_yojson.make_bytes v.data) :: assoc in
+  let assoc = ("crc", Pbrt_yojson.make_int (Int32.to_int v.crc)) :: assoc in
+  `Assoc assoc
+
+let rec encode_json_file_path (v:file_path) = 
+  let assoc = [] in 
+  let assoc = ("path", Pbrt_yojson.make_string v.path) :: assoc in
+  `Assoc assoc
+
+let rec encode_json_file_crc (v:file_crc) = 
+  let assoc = [] in 
+  let assoc = ("crc", Pbrt_yojson.make_int (Int32.to_int v.crc)) :: assoc in
+  `Assoc assoc
+
+let rec encode_json_empty (v:empty) = 
+Pbrt_yojson.make_unit v
+
+let rec encode_json_ping (v:ping) = 
+Pbrt_yojson.make_unit v
+
+let rec encode_json_pong (v:pong) = 
+Pbrt_yojson.make_unit v
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 JSON Decoding} *)
+
+let rec decode_json_file_chunk d =
+  let v = default_file_chunk_mutable () in
+  let assoc = match d with
+    | `Assoc assoc -> assoc
+    | _ -> assert(false)
+  in
+  List.iter (function 
+    | ("path", json_value) -> 
+      v.path <- Pbrt_yojson.string json_value "file_chunk" "path"
+    | ("data", json_value) -> 
+      v.data <- Pbrt_yojson.bytes json_value "file_chunk" "data"
+    | ("crc", json_value) -> 
+      v.crc <- Pbrt_yojson.int32 json_value "file_chunk" "crc"
+    
+    | (_, _) -> () (*Unknown fields are ignored*)
+  ) assoc;
+  ({
+    path = v.path;
+    data = v.data;
+    crc = v.crc;
+  } : file_chunk)
+
+let rec decode_json_file_path d =
+  let v = default_file_path_mutable () in
+  let assoc = match d with
+    | `Assoc assoc -> assoc
+    | _ -> assert(false)
+  in
+  List.iter (function 
+    | ("path", json_value) -> 
+      v.path <- Pbrt_yojson.string json_value "file_path" "path"
+    
+    | (_, _) -> () (*Unknown fields are ignored*)
+  ) assoc;
+  ({
+    path = v.path;
+  } : file_path)
+
+let rec decode_json_file_crc d =
+  let v = default_file_crc_mutable () in
+  let assoc = match d with
+    | `Assoc assoc -> assoc
+    | _ -> assert(false)
+  in
+  List.iter (function 
+    | ("crc", json_value) -> 
+      v.crc <- Pbrt_yojson.int32 json_value "file_crc" "crc"
+    
+    | (_, _) -> () (*Unknown fields are ignored*)
+  ) assoc;
+  ({
+    crc = v.crc;
+  } : file_crc)
+
+let rec decode_json_empty d =
+Pbrt_yojson.unit d "empty" "empty record"
+
+let rec decode_json_ping d =
+Pbrt_yojson.unit d "ping" "empty record"
+
+let rec decode_json_pong d =
+Pbrt_yojson.unit d "pong" "empty record"
+
+module FileServer = struct
+  open Pbrt_services.Value_mode
+  module Client = struct
+    open Pbrt_services
+    
+    let touch_file : (file_path, unary, empty, unary) Client.rpc =
+      (Client.mk_rpc 
+        ~package:[]
+        ~service_name:"FileServer" ~rpc_name:"touch_file"
+        ~req_mode:Client.Unary
+        ~res_mode:Client.Unary
+        ~encode_json_req:encode_json_file_path
+        ~encode_pb_req:encode_pb_file_path
+        ~decode_json_res:decode_json_empty
+        ~decode_pb_res:decode_pb_empty
+        () : (file_path, unary, empty, unary) Client.rpc)
+    open Pbrt_services
+    
+    let upload_file : (file_chunk, stream, file_crc, unary) Client.rpc =
+      (Client.mk_rpc 
+        ~package:[]
+        ~service_name:"FileServer" ~rpc_name:"upload_file"
+        ~req_mode:Client.Stream
+        ~res_mode:Client.Unary
+        ~encode_json_req:encode_json_file_chunk
+        ~encode_pb_req:encode_pb_file_chunk
+        ~decode_json_res:decode_json_file_crc
+        ~decode_pb_res:decode_pb_file_crc
+        () : (file_chunk, stream, file_crc, unary) Client.rpc)
+    open Pbrt_services
+    
+    let download_file : (file_path, unary, file_chunk, stream) Client.rpc =
+      (Client.mk_rpc 
+        ~package:[]
+        ~service_name:"FileServer" ~rpc_name:"download_file"
+        ~req_mode:Client.Unary
+        ~res_mode:Client.Stream
+        ~encode_json_req:encode_json_file_path
+        ~encode_pb_req:encode_pb_file_path
+        ~decode_json_res:decode_json_file_chunk
+        ~decode_pb_res:decode_pb_file_chunk
+        () : (file_path, unary, file_chunk, stream) Client.rpc)
+    open Pbrt_services
+    
+    let ping_pong : (ping, stream, pong, stream) Client.rpc =
+      (Client.mk_rpc 
+        ~package:[]
+        ~service_name:"FileServer" ~rpc_name:"ping_pong"
+        ~req_mode:Client.Stream
+        ~res_mode:Client.Stream
+        ~encode_json_req:encode_json_ping
+        ~encode_pb_req:encode_pb_ping
+        ~decode_json_res:decode_json_pong
+        ~decode_pb_res:decode_pb_pong
+        () : (ping, stream, pong, stream) Client.rpc)
+  end
+  
+  module Server = struct
+    open Pbrt_services
+    
+    let _rpc_touch_file : (file_path,unary,empty,unary) Server.rpc = 
+      (Server.mk_rpc ~name:"touch_file"
+        ~req_mode:Server.Unary
+        ~res_mode:Server.Unary
+        ~encode_json_res:encode_json_empty
+        ~encode_pb_res:encode_pb_empty
+        ~decode_json_req:decode_json_file_path
+        ~decode_pb_req:decode_pb_file_path
+        () : _ Server.rpc)
+    
+    let _rpc_upload_file : (file_chunk,stream,file_crc,unary) Server.rpc = 
+      (Server.mk_rpc ~name:"upload_file"
+        ~req_mode:Server.Stream
+        ~res_mode:Server.Unary
+        ~encode_json_res:encode_json_file_crc
+        ~encode_pb_res:encode_pb_file_crc
+        ~decode_json_req:decode_json_file_chunk
+        ~decode_pb_req:decode_pb_file_chunk
+        () : _ Server.rpc)
+    
+    let _rpc_download_file : (file_path,unary,file_chunk,stream) Server.rpc = 
+      (Server.mk_rpc ~name:"download_file"
+        ~req_mode:Server.Unary
+        ~res_mode:Server.Stream
+        ~encode_json_res:encode_json_file_chunk
+        ~encode_pb_res:encode_pb_file_chunk
+        ~decode_json_req:decode_json_file_path
+        ~decode_pb_req:decode_pb_file_path
+        () : _ Server.rpc)
+    
+    let _rpc_ping_pong : (ping,stream,pong,stream) Server.rpc = 
+      (Server.mk_rpc ~name:"ping_pong"
+        ~req_mode:Server.Stream
+        ~res_mode:Server.Stream
+        ~encode_json_res:encode_json_pong
+        ~encode_pb_res:encode_pb_pong
+        ~decode_json_req:decode_json_ping
+        ~decode_pb_req:decode_pb_ping
+        () : _ Server.rpc)
+    
+    let make
+      ~touch_file
+      ~upload_file
+      ~download_file
+      ~ping_pong
+      () : _ Server.t =
+      { Server.
+        service_name="FileServer";
+        package=[];
+        handlers=[
+           (touch_file _rpc_touch_file);
+           (upload_file _rpc_upload_file);
+           (download_file _rpc_download_file);
+           (ping_pong _rpc_ping_pong);
+        ];
+      }
+  end
+  
+end

--- a/src/examples/file_server.mli.expected
+++ b/src/examples/file_server.mli.expected
@@ -1,0 +1,195 @@
+
+(** Code for file_server.proto *)
+
+(* generated from "file_server.proto", do not edit *)
+
+
+
+(** {2 Types} *)
+
+type file_chunk = {
+  path : string;
+  data : bytes;
+  crc : int32;
+}
+
+type file_path = {
+  path : string;
+}
+
+type file_crc = {
+  crc : int32;
+}
+
+type empty = unit
+
+type ping = unit
+
+type pong = unit
+
+
+(** {2 Basic values} *)
+
+val default_file_chunk : 
+  ?path:string ->
+  ?data:bytes ->
+  ?crc:int32 ->
+  unit ->
+  file_chunk
+(** [default_file_chunk ()] is the default value for type [file_chunk] *)
+
+val default_file_path : 
+  ?path:string ->
+  unit ->
+  file_path
+(** [default_file_path ()] is the default value for type [file_path] *)
+
+val default_file_crc : 
+  ?crc:int32 ->
+  unit ->
+  file_crc
+(** [default_file_crc ()] is the default value for type [file_crc] *)
+
+val default_empty : unit
+(** [default_empty ()] is the default value for type [empty] *)
+
+val default_ping : unit
+(** [default_ping ()] is the default value for type [ping] *)
+
+val default_pong : unit
+(** [default_pong ()] is the default value for type [pong] *)
+
+
+(** {2 Formatters} *)
+
+val pp_file_chunk : Format.formatter -> file_chunk -> unit 
+(** [pp_file_chunk v] formats v *)
+
+val pp_file_path : Format.formatter -> file_path -> unit 
+(** [pp_file_path v] formats v *)
+
+val pp_file_crc : Format.formatter -> file_crc -> unit 
+(** [pp_file_crc v] formats v *)
+
+val pp_empty : Format.formatter -> empty -> unit 
+(** [pp_empty v] formats v *)
+
+val pp_ping : Format.formatter -> ping -> unit 
+(** [pp_ping v] formats v *)
+
+val pp_pong : Format.formatter -> pong -> unit 
+(** [pp_pong v] formats v *)
+
+
+(** {2 Protobuf Encoding} *)
+
+val encode_pb_file_chunk : file_chunk -> Pbrt.Encoder.t -> unit
+(** [encode_pb_file_chunk v encoder] encodes [v] with the given [encoder] *)
+
+val encode_pb_file_path : file_path -> Pbrt.Encoder.t -> unit
+(** [encode_pb_file_path v encoder] encodes [v] with the given [encoder] *)
+
+val encode_pb_file_crc : file_crc -> Pbrt.Encoder.t -> unit
+(** [encode_pb_file_crc v encoder] encodes [v] with the given [encoder] *)
+
+val encode_pb_empty : empty -> Pbrt.Encoder.t -> unit
+(** [encode_pb_empty v encoder] encodes [v] with the given [encoder] *)
+
+val encode_pb_ping : ping -> Pbrt.Encoder.t -> unit
+(** [encode_pb_ping v encoder] encodes [v] with the given [encoder] *)
+
+val encode_pb_pong : pong -> Pbrt.Encoder.t -> unit
+(** [encode_pb_pong v encoder] encodes [v] with the given [encoder] *)
+
+
+(** {2 Protobuf Decoding} *)
+
+val decode_pb_file_chunk : Pbrt.Decoder.t -> file_chunk
+(** [decode_pb_file_chunk decoder] decodes a [file_chunk] binary value from [decoder] *)
+
+val decode_pb_file_path : Pbrt.Decoder.t -> file_path
+(** [decode_pb_file_path decoder] decodes a [file_path] binary value from [decoder] *)
+
+val decode_pb_file_crc : Pbrt.Decoder.t -> file_crc
+(** [decode_pb_file_crc decoder] decodes a [file_crc] binary value from [decoder] *)
+
+val decode_pb_empty : Pbrt.Decoder.t -> empty
+(** [decode_pb_empty decoder] decodes a [empty] binary value from [decoder] *)
+
+val decode_pb_ping : Pbrt.Decoder.t -> ping
+(** [decode_pb_ping decoder] decodes a [ping] binary value from [decoder] *)
+
+val decode_pb_pong : Pbrt.Decoder.t -> pong
+(** [decode_pb_pong decoder] decodes a [pong] binary value from [decoder] *)
+
+
+(** {2 Protobuf YoJson Encoding} *)
+
+val encode_json_file_chunk : file_chunk -> Yojson.Basic.t
+(** [encode_json_file_chunk v encoder] encodes [v] to to json *)
+
+val encode_json_file_path : file_path -> Yojson.Basic.t
+(** [encode_json_file_path v encoder] encodes [v] to to json *)
+
+val encode_json_file_crc : file_crc -> Yojson.Basic.t
+(** [encode_json_file_crc v encoder] encodes [v] to to json *)
+
+val encode_json_empty : empty -> Yojson.Basic.t
+(** [encode_json_empty v encoder] encodes [v] to to json *)
+
+val encode_json_ping : ping -> Yojson.Basic.t
+(** [encode_json_ping v encoder] encodes [v] to to json *)
+
+val encode_json_pong : pong -> Yojson.Basic.t
+(** [encode_json_pong v encoder] encodes [v] to to json *)
+
+
+(** {2 JSON Decoding} *)
+
+val decode_json_file_chunk : Yojson.Basic.t -> file_chunk
+(** [decode_json_file_chunk decoder] decodes a [file_chunk] value from [decoder] *)
+
+val decode_json_file_path : Yojson.Basic.t -> file_path
+(** [decode_json_file_path decoder] decodes a [file_path] value from [decoder] *)
+
+val decode_json_file_crc : Yojson.Basic.t -> file_crc
+(** [decode_json_file_crc decoder] decodes a [file_crc] value from [decoder] *)
+
+val decode_json_empty : Yojson.Basic.t -> empty
+(** [decode_json_empty decoder] decodes a [empty] value from [decoder] *)
+
+val decode_json_ping : Yojson.Basic.t -> ping
+(** [decode_json_ping decoder] decodes a [ping] value from [decoder] *)
+
+val decode_json_pong : Yojson.Basic.t -> pong
+(** [decode_json_pong decoder] decodes a [pong] value from [decoder] *)
+
+
+(** {2 Services} *)
+
+(** FileServer service *)
+module FileServer : sig
+  open Pbrt_services
+  open Pbrt_services.Value_mode
+  
+  module Client : sig
+    
+    val touch_file : (file_path, unary, empty, unary) Client.rpc
+    
+    val upload_file : (file_chunk, stream, file_crc, unary) Client.rpc
+    
+    val download_file : (file_path, unary, file_chunk, stream) Client.rpc
+    
+    val ping_pong : (ping, stream, pong, stream) Client.rpc
+  end
+  
+  module Server : sig
+    (** Produce a server implementation from handlers *)
+    val make : 
+      touch_file:((file_path, unary, empty, unary) Server.rpc -> 'handler) ->
+      upload_file:((file_chunk, stream, file_crc, unary) Server.rpc -> 'handler) ->
+      download_file:((file_path, unary, file_chunk, stream) Server.rpc -> 'handler) ->
+      ping_pong:((ping, stream, pong, stream) Server.rpc -> 'handler) ->
+      unit -> 'handler Pbrt_services.Server.t
+  end
+end

--- a/src/examples/orgchart.ml.expected
+++ b/src/examples/orgchart.ml.expected
@@ -1,0 +1,236 @@
+[@@@ocaml.warning "-27-30-39"]
+
+type person = {
+  name : string;
+  age : int64;
+}
+
+type store = {
+  address : string;
+  employees : person list;
+  clients : person list;
+}
+
+type company = {
+  name : string;
+  stores : store list;
+  subsidiaries : company list;
+}
+
+let rec default_person 
+  ?name:((name:string) = "")
+  ?age:((age:int64) = 0L)
+  () : person  = {
+  name;
+  age;
+}
+
+let rec default_store 
+  ?address:((address:string) = "")
+  ?employees:((employees:person list) = [])
+  ?clients:((clients:person list) = [])
+  () : store  = {
+  address;
+  employees;
+  clients;
+}
+
+let rec default_company 
+  ?name:((name:string) = "")
+  ?stores:((stores:store list) = [])
+  ?subsidiaries:((subsidiaries:company list) = [])
+  () : company  = {
+  name;
+  stores;
+  subsidiaries;
+}
+
+type person_mutable = {
+  mutable name : string;
+  mutable age : int64;
+}
+
+let default_person_mutable () : person_mutable = {
+  name = "";
+  age = 0L;
+}
+
+type store_mutable = {
+  mutable address : string;
+  mutable employees : person list;
+  mutable clients : person list;
+}
+
+let default_store_mutable () : store_mutable = {
+  address = "";
+  employees = [];
+  clients = [];
+}
+
+type company_mutable = {
+  mutable name : string;
+  mutable stores : store list;
+  mutable subsidiaries : company list;
+}
+
+let default_company_mutable () : company_mutable = {
+  name = "";
+  stores = [];
+  subsidiaries = [];
+}
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Formatters} *)
+
+let rec pp_person fmt (v:person) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "name" Pbrt.Pp.pp_string fmt v.name;
+    Pbrt.Pp.pp_record_field ~first:false "age" Pbrt.Pp.pp_int64 fmt v.age;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_store fmt (v:store) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "address" Pbrt.Pp.pp_string fmt v.address;
+    Pbrt.Pp.pp_record_field ~first:false "employees" (Pbrt.Pp.pp_list pp_person) fmt v.employees;
+    Pbrt.Pp.pp_record_field ~first:false "clients" (Pbrt.Pp.pp_list pp_person) fmt v.clients;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_company fmt (v:company) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "name" Pbrt.Pp.pp_string fmt v.name;
+    Pbrt.Pp.pp_record_field ~first:false "stores" (Pbrt.Pp.pp_list pp_store) fmt v.stores;
+    Pbrt.Pp.pp_record_field ~first:false "subsidiaries" (Pbrt.Pp.pp_list pp_company) fmt v.subsidiaries;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Protobuf Encoding} *)
+
+let rec encode_pb_person (v:person) encoder = 
+  Pbrt.Encoder.string v.name encoder;
+  Pbrt.Encoder.key 1 Pbrt.Bytes encoder; 
+  Pbrt.Encoder.int64_as_zigzag v.age encoder;
+  Pbrt.Encoder.key 2 Pbrt.Varint encoder; 
+  ()
+
+let rec encode_pb_store (v:store) encoder = 
+  Pbrt.Encoder.string v.address encoder;
+  Pbrt.Encoder.key 1 Pbrt.Bytes encoder; 
+  Pbrt.List_util.rev_iter_with (fun x encoder -> 
+    Pbrt.Encoder.nested encode_pb_person x encoder;
+    Pbrt.Encoder.key 2 Pbrt.Bytes encoder; 
+  ) v.employees encoder;
+  Pbrt.List_util.rev_iter_with (fun x encoder -> 
+    Pbrt.Encoder.nested encode_pb_person x encoder;
+    Pbrt.Encoder.key 3 Pbrt.Bytes encoder; 
+  ) v.clients encoder;
+  ()
+
+let rec encode_pb_company (v:company) encoder = 
+  Pbrt.Encoder.string v.name encoder;
+  Pbrt.Encoder.key 1 Pbrt.Bytes encoder; 
+  Pbrt.List_util.rev_iter_with (fun x encoder -> 
+    Pbrt.Encoder.nested encode_pb_store x encoder;
+    Pbrt.Encoder.key 2 Pbrt.Bytes encoder; 
+  ) v.stores encoder;
+  Pbrt.List_util.rev_iter_with (fun x encoder -> 
+    Pbrt.Encoder.nested encode_pb_company x encoder;
+    Pbrt.Encoder.key 3 Pbrt.Bytes encoder; 
+  ) v.subsidiaries encoder;
+  ()
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Protobuf Decoding} *)
+
+let rec decode_pb_person d =
+  let v = default_person_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.name <- Pbrt.Decoder.string d;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(person), field(1)" pk
+    | Some (2, Pbrt.Varint) -> begin
+      v.age <- Pbrt.Decoder.int64_as_zigzag d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(person), field(2)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    name = v.name;
+    age = v.age;
+  } : person)
+
+let rec decode_pb_store d =
+  let v = default_store_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.clients <- List.rev v.clients;
+      v.employees <- List.rev v.employees;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.address <- Pbrt.Decoder.string d;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(store), field(1)" pk
+    | Some (2, Pbrt.Bytes) -> begin
+      v.employees <- (decode_pb_person (Pbrt.Decoder.nested d)) :: v.employees;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(store), field(2)" pk
+    | Some (3, Pbrt.Bytes) -> begin
+      v.clients <- (decode_pb_person (Pbrt.Decoder.nested d)) :: v.clients;
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(store), field(3)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    address = v.address;
+    employees = v.employees;
+    clients = v.clients;
+  } : store)
+
+let rec decode_pb_company d =
+  let v = default_company_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.subsidiaries <- List.rev v.subsidiaries;
+      v.stores <- List.rev v.stores;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.name <- Pbrt.Decoder.string d;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(company), field(1)" pk
+    | Some (2, Pbrt.Bytes) -> begin
+      v.stores <- (decode_pb_store (Pbrt.Decoder.nested d)) :: v.stores;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(company), field(2)" pk
+    | Some (3, Pbrt.Bytes) -> begin
+      v.subsidiaries <- (decode_pb_company (Pbrt.Decoder.nested d)) :: v.subsidiaries;
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(company), field(3)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    name = v.name;
+    stores = v.stores;
+    subsidiaries = v.subsidiaries;
+  } : company)

--- a/src/examples/orgchart.mli.expected
+++ b/src/examples/orgchart.mli.expected
@@ -1,0 +1,87 @@
+
+(** Code for orgchart.proto *)
+
+(* generated from "orgchart.proto", do not edit *)
+
+
+
+(** {2 Types} *)
+
+type person = {
+  name : string;
+  age : int64;
+}
+
+type store = {
+  address : string;
+  employees : person list;
+  clients : person list;
+}
+
+type company = {
+  name : string;
+  stores : store list;
+  subsidiaries : company list;
+}
+
+
+(** {2 Basic values} *)
+
+val default_person : 
+  ?name:string ->
+  ?age:int64 ->
+  unit ->
+  person
+(** [default_person ()] is the default value for type [person] *)
+
+val default_store : 
+  ?address:string ->
+  ?employees:person list ->
+  ?clients:person list ->
+  unit ->
+  store
+(** [default_store ()] is the default value for type [store] *)
+
+val default_company : 
+  ?name:string ->
+  ?stores:store list ->
+  ?subsidiaries:company list ->
+  unit ->
+  company
+(** [default_company ()] is the default value for type [company] *)
+
+
+(** {2 Formatters} *)
+
+val pp_person : Format.formatter -> person -> unit 
+(** [pp_person v] formats v *)
+
+val pp_store : Format.formatter -> store -> unit 
+(** [pp_store v] formats v *)
+
+val pp_company : Format.formatter -> company -> unit 
+(** [pp_company v] formats v *)
+
+
+(** {2 Protobuf Encoding} *)
+
+val encode_pb_person : person -> Pbrt.Encoder.t -> unit
+(** [encode_pb_person v encoder] encodes [v] with the given [encoder] *)
+
+val encode_pb_store : store -> Pbrt.Encoder.t -> unit
+(** [encode_pb_store v encoder] encodes [v] with the given [encoder] *)
+
+val encode_pb_company : company -> Pbrt.Encoder.t -> unit
+(** [encode_pb_company v encoder] encodes [v] with the given [encoder] *)
+
+
+(** {2 Protobuf Decoding} *)
+
+val decode_pb_person : Pbrt.Decoder.t -> person
+(** [decode_pb_person decoder] decodes a [person] binary value from [decoder] *)
+
+val decode_pb_store : Pbrt.Decoder.t -> store
+(** [decode_pb_store decoder] decodes a [store] binary value from [decoder] *)
+
+val decode_pb_company : Pbrt.Decoder.t -> company
+(** [decode_pb_company decoder] decodes a [company] binary value from [decoder] *)


### PR DESCRIPTION
Hello team,

Following our discussion in issue #204 , I've made a small adjustment to the testing workflow. This is a minor change, but I believe it could reveal beneficial.

Here's what's been done:

1. **Expect Tests**: For each `ml` and `mli` file generated by a dune rule in the `src/examples/` directory, corresponding `*.ml.expected` and `*.mli.expected` files have been added. This will help us keep track of the impact of PRs on the generated code.

2. **Dune Rule**: A dune rule has been added to diff the generated files against their expected reference as part of `dune @runtest`. In case the generated code changes, updating the expect files is straightforward. You just need to run `dune promote`, and the expect files will be updated by dune to match the new output.

This change doesn't introduce any new dependencies or affect the non-testing code. It's a small step towards continuing to improve on the existing testing workflow.

I find that it can be hard to know beforehand whether this new test setup will add undue friction. If in practice, this change doesn't work as well as I hope, it can easily be reverted without impacting the rest of the code.

Looking forward to your feedback.