### PR TITLE
Expose one-of per-constructor options

### DIFF
--- a/src/compilerlib/pb_codegen_backend.ml
+++ b/src/compilerlib/pb_codegen_backend.ml
@@ -328,6 +328,7 @@ let variant_of_oneof ?include_oneof_name ~outer_message_names ~unsigned_tag
               (match field_type with
               | Ft_unit -> Vct_nullary
               | _ -> Vct_non_nullary_constructor field_type);
+            vc_options = field.field_options;
           })
       oneof_field.Tt.oneof_fields
   in

--- a/src/compilerlib/pb_codegen_decode_binary.ml
+++ b/src/compilerlib/pb_codegen_decode_binary.ml
@@ -161,6 +161,7 @@ let gen_rft_variant sc r_name rf_label { Ot.v_constructors; _ } =
         vc_field_type;
         vc_encoding_number;
         vc_payload_kind = pk;
+        vc_options = _;
       } =
         variant_constructor
       in
@@ -281,6 +282,7 @@ let gen_variant ?and_ { Ot.v_name; v_constructors } sc =
       vc_field_type;
       vc_encoding_number;
       vc_payload_kind = pk;
+      vc_options = _;
     } =
       variant_constructor
     in

--- a/src/compilerlib/pb_codegen_encode_binary.ml
+++ b/src/compilerlib/pb_codegen_encode_binary.ml
@@ -139,6 +139,7 @@ let gen_rft_variant sc var_name { Ot.v_constructors; _ } =
         vc_field_type;
         vc_encoding_number;
         vc_payload_kind;
+        vc_options = _;
       } =
         constructor
       in
@@ -235,6 +236,7 @@ let gen_variant ?and_ variant sc =
             vc_field_type;
             vc_encoding_number;
             vc_payload_kind;
+            vc_options = _;
           } =
             variant_constructor
           in

--- a/src/compilerlib/pb_codegen_ocaml_type.ml
+++ b/src/compilerlib/pb_codegen_ocaml_type.ml
@@ -106,6 +106,7 @@ and variant_constructor = {
   vc_field_type: variant_constructor_type;
   vc_encoding_number: encoding_number;
   vc_payload_kind: payload_kind;
+  vc_options: Pb_option.set;
 }
 
 and variant_constructor_type =

--- a/src/compilerlib/pb_codegen_ocaml_type_dump.ml
+++ b/src/compilerlib/pb_codegen_ocaml_type_dump.ml
@@ -170,7 +170,8 @@ module PP = struct
     F.linep sc "    Field Type: %s\n"
       (string_of_variant_constructor_type vc.vc_field_type);
     F.linep sc "    Encoding Number: %d, Payload Kind: %s" vc.vc_encoding_number
-      (string_of_payload_kind vc.vc_payload_kind)
+      (string_of_payload_kind vc.vc_payload_kind);
+    F.linep sc "    Options: %s" (string_of_options vc.vc_options)
 
   (* Helper function to convert variant_constructor_type to string *)
   and string_of_variant_constructor_type vct =

--- a/src/tests/expectation/option_processing.ml.expected
+++ b/src/tests/expectation/option_processing.ml.expected
@@ -14,6 +14,7 @@ type person_location = {
 type person_id =
   | X of string
   | Y of int32
+  | Z of float
 
 and person = {
   id : int64;
@@ -96,10 +97,17 @@ and default_person
       Field Type: Vct_non_nullary_constructor: Ft_basic_type: Bt_string
 
       Encoding Number: 6, Payload Kind: Pk_bytes
+      Options: {"validate.rules.string.prefix": Constant_string "foo"}
     Constructor: Y
       Field Type: Vct_non_nullary_constructor: Ft_basic_type: Bt_int32
 
       Encoding Number: 7, Payload Kind: Pk_varint (zigzag: false)
+      Options: {"validate.rules.int32.gt": Constant_int 0}
+    Constructor: Z
+      Field Type: Vct_non_nullary_constructor: Ft_basic_type: Bt_float
+
+      Encoding Number: 8, Payload Kind: Pk_bits32
+      Options: {}
   Options: {}
 *)
 

--- a/src/tests/expectation/option_processing.proto
+++ b/src/tests/expectation/option_processing.proto
@@ -35,7 +35,8 @@ message Person {
   oneof id {
     option (validate.required) = true;
 
-    string x = 6;
-    int32  y = 7;
+    string x = 6 [(validate.rules).string.prefix = "foo"];
+    int32  y = 7 [(validate.rules).int32.gt = 0];
+    float  z = 8;
   }
 }


### PR DESCRIPTION
This PR exposes per-constructor options within one-of, which were previously missing. Corresponding test case is included.