### PR TITLE
More compliant options parsing

### DIFF
--- a/src/compilerlib/dune
+++ b/src/compilerlib/dune
@@ -14,8 +14,8 @@
    pb_codegen_encode_yojson pb_codegen_formatting pb_codegen_ocaml_type_dump
    pb_codegen_ocaml_type pb_codegen_pp pb_codegen_plugin pb_codegen_types
    pb_codegen_services pb_codegen_util pb_exception pb_field_type pb_location
-   pb_logger pb_option pb_parsing pb_parsing_lexer pb_parsing_parser
-   pb_parsing_parse_tree pb_parsing_util pb_typing_graph pb_typing
-   pb_typing_recursion pb_typing_resolution pb_typing_type_tree
+   pb_logger pb_option pb_raw_option pb_parsing pb_parsing_lexer
+   pb_parsing_parser pb_parsing_parse_tree pb_parsing_util pb_typing_graph
+   pb_typing pb_typing_recursion pb_typing_resolution pb_typing_type_tree
    pb_typing_util pb_typing_validation pb_util pb_format_util)
  (libraries stdlib-shims))

--- a/src/compilerlib/pb_codegen_all.ml
+++ b/src/compilerlib/pb_codegen_all.ml
@@ -40,7 +40,7 @@ let new_ocaml_mod ~proto_file_options ~proto_file_name () : ocaml_mod =
   let self = { ml = F.empty_scope (); mli = F.empty_scope () } in
 
   let print_ppx sc =
-    match Pb_option.get_ext proto_file_options "ocaml_file_ppx" with
+    match Pb_raw_option.get_ext proto_file_options "ocaml_file_ppx" with
     | None -> ()
     | Some Pb_option.(Scalar_value (Constant_string s)) ->
       F.linep sc "[@@@%s]" s

--- a/src/compilerlib/pb_codegen_all.ml
+++ b/src/compilerlib/pb_codegen_all.ml
@@ -40,7 +40,7 @@ let new_ocaml_mod ~proto_file_options ~proto_file_name () : ocaml_mod =
   let self = { ml = F.empty_scope (); mli = F.empty_scope () } in
 
   let print_ppx sc =
-    match Pb_option.get proto_file_options "ocaml_file_ppx" with
+    match Pb_option.get_ext proto_file_options "ocaml_file_ppx" with
     | None -> ()
     | Some Pb_option.(Scalar_value (Constant_string s)) ->
       F.linep sc "[@@@%s]" s

--- a/src/compilerlib/pb_codegen_all.mli
+++ b/src/compilerlib/pb_codegen_all.mli
@@ -12,7 +12,7 @@ type ocaml_mod = {
 val codegen :
   Ot.proto ->
   generate_make:bool ->
-  proto_file_options:Pb_option.set ->
+  proto_file_options:Pb_raw_option.set ->
   proto_file_name:string ->
   services:bool ->
   Plugin.t list ->

--- a/src/compilerlib/pb_codegen_backend.ml
+++ b/src/compilerlib/pb_codegen_backend.ml
@@ -195,7 +195,7 @@ let encoding_info_of_field_type ~all_types field_type : Ot.payload_kind =
 let encoding_of_field ~all_types (field : (Pb_field_type.resolved, 'a) Tt.field)
     =
   let packed =
-    match Typing_util.field_option field "packed" with
+    match Typing_util.field_option field [ Pb_option.Simple_name "packed" ] with
     | Some Pb_option.(Scalar_value (Constant_bool x)) -> x
     | Some _ -> E.invalid_packed_option (Typing_util.field_name field)
     | None -> false
@@ -209,34 +209,34 @@ let encoding_of_field ~all_types (field : (Pb_field_type.resolved, 'a) Tt.field)
 let compile_field_type ~unsigned_tag ~(all_types : _ Tt.proto_type list)
     file_options field_options file_name field_type : Ot.field_type =
   let ocaml_type =
-    match Pb_option.get field_options "ocaml_type" with
+    match Pb_option.get_ext field_options "ocaml_type" with
     | Some Pb_option.(Scalar_value (Constant_literal "int_t")) -> `Int_t
     | _ -> `None
   in
 
   let int32_type =
-    match Pb_option.get file_options "int32_type" with
+    match Pb_option.get_ext file_options "int32_type" with
     | Some Pb_option.(Scalar_value (Pb_option.Constant_literal "int_t")) ->
       Ot.(Ft_basic_type Bt_int)
     | _ -> Ot.(Ft_basic_type Bt_int32)
   in
 
   let uint32_type =
-    match Pb_option.get file_options "int32_type" with
+    match Pb_option.get_ext file_options "int32_type" with
     | Some Pb_option.(Scalar_value (Constant_literal "int_t")) ->
       Ot.(Ft_basic_type Bt_int)
     | _ -> Ot.(Ft_basic_type Bt_uint32)
   in
 
   let int64_type =
-    match Pb_option.get file_options "int64_type" with
+    match Pb_option.get_ext file_options "int64_type" with
     | Some Pb_option.(Scalar_value (Constant_literal "int_t")) ->
       Ot.(Ft_basic_type Bt_int)
     | _ -> Ot.(Ft_basic_type Bt_int64)
   in
 
   let uint64_type =
-    match Pb_option.get file_options "int64_type" with
+    match Pb_option.get_ext file_options "int64_type" with
     | Some Pb_option.(Scalar_value (Constant_literal "int_t")) ->
       Ot.(Ft_basic_type Bt_int)
     | _ -> Ot.(Ft_basic_type Bt_uint64)
@@ -289,13 +289,13 @@ let compile_field_type ~unsigned_tag ~(all_types : _ Tt.proto_type list)
   | `User_defined id, _ -> user_defined_type_of_id ~all_types ~file_name id
 
 let is_mutable ?field_name field_options =
-  match Pb_option.get field_options "ocaml_mutable" with
+  match Pb_option.get_ext field_options "ocaml_mutable" with
   | Some Pb_option.(Scalar_value (Constant_bool v)) -> v
   | Some _ -> Pb_exception.invalid_mutable_option ?field_name ()
   | None -> false
 
 let ocaml_container field_options =
-  match Pb_option.get field_options "ocaml_container" with
+  match Pb_option.get_ext field_options "ocaml_container" with
   | None -> None
   | Some Pb_option.(Scalar_value (Constant_literal container_name)) ->
     Some container_name
@@ -371,7 +371,7 @@ let process_all_types_ppx_extension file_name file_options
   match type_level_ppx_extension with
   | Some x -> Some x
   | None ->
-    Pb_option.get file_options "ocaml_all_types_ppx"
+    Pb_option.get_ext file_options "ocaml_all_types_ppx"
     |> string_of_string_option file_name
 
 let compile_message ~(unsigned_tag : bool) (file_options : Pb_option.set)
@@ -388,7 +388,8 @@ let compile_message ~(unsigned_tag : bool) (file_options : Pb_option.set)
   let { Tt.message_names; _ } = scope in
 
   let type_level_ppx_extension =
-    Typing_util.message_option message "ocaml_type_ppx"
+    Typing_util.message_option message
+      [ Pb_option.Extension_name "ocaml_type_ppx" ]
     |> string_of_string_option message_name
     |> process_all_types_ppx_extension file_name file_options
   in
@@ -633,7 +634,7 @@ let compile_enum file_options file_name scope enum =
   in
 
   let type_level_ppx_extension =
-    Typing_util.enum_option enum "ocaml_enum_ppx"
+    Typing_util.enum_option enum [ Pb_option.Extension_name "ocaml_enum_ppx" ]
     |> string_of_string_option enum_name
     |> process_all_types_ppx_extension file_name file_options
   in

--- a/src/compilerlib/pb_codegen_backend.ml
+++ b/src/compilerlib/pb_codegen_backend.ml
@@ -195,7 +195,7 @@ let encoding_info_of_field_type ~all_types field_type : Ot.payload_kind =
 let encoding_of_field ~all_types (field : (Pb_field_type.resolved, 'a) Tt.field)
     =
   let packed =
-    match Typing_util.field_option field [ Pb_option.Simple_name "packed" ] with
+    match Typing_util.field_option field (Pb_option.Simple_name "packed") with
     | Some Pb_option.(Scalar_value (Constant_bool x)) -> x
     | Some _ -> E.invalid_packed_option (Typing_util.field_name field)
     | None -> false
@@ -389,7 +389,7 @@ let compile_message ~(unsigned_tag : bool) (file_options : Pb_option.set)
 
   let type_level_ppx_extension =
     Typing_util.message_option message
-      [ Pb_option.Extension_name "ocaml_type_ppx" ]
+      (Pb_option.Extension_name "ocaml_type_ppx")
     |> string_of_string_option message_name
     |> process_all_types_ppx_extension file_name file_options
   in
@@ -634,7 +634,7 @@ let compile_enum file_options file_name scope enum =
   in
 
   let type_level_ppx_extension =
-    Typing_util.enum_option enum [ Pb_option.Extension_name "ocaml_enum_ppx" ]
+    Typing_util.enum_option enum (Pb_option.Extension_name "ocaml_enum_ppx")
     |> string_of_string_option enum_name
     |> process_all_types_ppx_extension file_name file_options
   in

--- a/src/compilerlib/pb_codegen_ocaml_type_dump.ml
+++ b/src/compilerlib/pb_codegen_ocaml_type_dump.ml
@@ -74,29 +74,6 @@ module PP = struct
     | Constant_literal s ->
       Printf.sprintf "Constant_literal %S" (String.escaped s)
 
-  (* Helper function to convert value to string *)
-  let rec string_of_value value =
-    match value with
-    | Pb_option.Scalar_value c -> string_of_constant c
-    | Message_literal ml -> string_of_message_literal ml
-    | List_literal ll -> string_of_list_literal ll
-
-  (* Helper function to convert message_literal to string *)
-  and string_of_message_literal ml =
-    "{"
-    ^ String.concat ", "
-        (List.map
-           (fun (k, v) -> Printf.sprintf "%S: %s" k (string_of_value v))
-           ml)
-    ^ "}"
-
-  (* Helper function to convert list_literal to string *)
-  and string_of_list_literal ll =
-    "[" ^ String.concat ", " (List.map string_of_value ll) ^ "]"
-
-  (* Function to convert options (message_literal) to string *)
-  let string_of_options options = string_of_message_literal options
-
   (* Helper function to convert default_value to string *)
   let string_of_default_value dv =
     match dv with
@@ -171,7 +148,8 @@ module PP = struct
       (string_of_variant_constructor_type vc.vc_field_type);
     F.linep sc "    Encoding Number: %d, Payload Kind: %s" vc.vc_encoding_number
       (string_of_payload_kind vc.vc_payload_kind);
-    F.linep sc "    Options: %s" (string_of_options vc.vc_options)
+    F.linep sc "    Options: %s"
+      (Format.asprintf "%a" Pb_option.pp_set vc.vc_options)
 
   (* Helper function to convert variant_constructor_type to string *)
   and string_of_variant_constructor_type vct =
@@ -189,7 +167,8 @@ module PP = struct
   and print_record_field sc record_field =
     F.linep sc "- Field: %s" record_field.rf_label;
     print_record_field_type sc record_field.rf_field_type;
-    F.linep sc "  Field options: %s" (string_of_options record_field.rf_options)
+    F.linep sc "  Field options: %s"
+      (Format.asprintf "%a" Pb_option.pp_set record_field.rf_options)
 
   (* Recursive function to print a const_variant *)
   let rec print_const_variant sc const_variant =
@@ -201,7 +180,8 @@ module PP = struct
     F.linep sc "  Constructor: %s" cvc.cvc_name;
     F.linep sc "    Binary Value: %d, String Value: %s" cvc.cvc_binary_value
       cvc.cvc_string_value;
-    F.linep sc "    Options: %s" (string_of_options cvc.cvc_options)
+    F.linep sc "    Options: %s"
+      (Format.asprintf "%a" Pb_option.pp_set cvc.cvc_options)
 
   (* Recursive function to print the type_spec *)
   let print_type_spec sc type_spec =
@@ -215,7 +195,8 @@ module PP = struct
   let print_type sc type_ =
     F.linep sc "Module Prefix: %s" type_.module_prefix;
     print_type_spec sc type_.spec;
-    F.linep sc "Options: %s" (string_of_options type_.type_options);
+    F.linep sc "Options: %s"
+      (Format.asprintf "%a" Pb_option.pp_set type_.type_options);
     match type_.type_level_ppx_extension with
     | Some ext -> F.linep sc "PPX Extension: %s" ext
     | None -> ()

--- a/src/compilerlib/pb_option.ml
+++ b/src/compilerlib/pb_option.ml
@@ -74,11 +74,6 @@ let add option_set option_name value =
       "This should not happen, partition should result in at most single item \
        in left component"
 
-let merge set1 set2 =
-  List.fold_left
-    (fun acc (option_name, value) -> add acc option_name value)
-    set1 set2
-
 let get t option_name =
   match List.find (fun (other, _) -> option_name_equal option_name other) t with
   | _, c -> Some c

--- a/src/compilerlib/pb_option.ml
+++ b/src/compilerlib/pb_option.ml
@@ -5,6 +5,12 @@ type constant =
   | Constant_float of float
   | Constant_literal of string
 
+type name_part =
+  | Simple_name of string
+  | Extension_name of string
+
+type option_name = name_part list
+
 type message_literal = (string * value) list
 and list_literal = value list
 
@@ -13,18 +19,34 @@ and value =
   | Message_literal of message_literal
   | List_literal of list_literal
 
-type option_name = string
 type t = option_name * value
 type set = t list
 
+let name_part_to_string = function
+  | Simple_name s -> s
+  | Extension_name s -> "(" ^ s ^ ")"
+
+let stringify_option_name (option_name : option_name) : string =
+  let str_list = List.map name_part_to_string option_name in
+  String.concat "." str_list
+
+let name_part_equal a b =
+  match a, b with
+  | Simple_name a, Simple_name b -> String.equal a b
+  | Extension_name a, Extension_name b -> String.equal a b
+  | _ -> false
+
+let option_name_equal a b = List.equal name_part_equal a b
 let empty = []
 let add t option_name value = (option_name, value) :: t
 let merge t1 t2 = t2 @ t1
 
 let get t option_name =
-  match List.assoc option_name t with
-  | c -> Some c
+  match List.find (fun (other, _) -> option_name_equal option_name other) t with
+  | _, c -> Some c
   | exception Not_found -> None
+
+let get_ext t option_name = get t [ Extension_name option_name ]
 
 let pp_constant ppf = function
   | Constant_string s -> Format.fprintf ppf "%S" s
@@ -56,7 +78,9 @@ and pp_message_field ppf (field, value) =
   Format.fprintf ppf "%S: %a" field pp_value value
 
 let pp_t ppf (name, value) =
-  Format.fprintf ppf "{@;<1 2>%S: %a@;<1 2>}" name pp_value value
+  Format.fprintf ppf "{@;<1 2>%S: %a@;<1 2>}"
+    (stringify_option_name name)
+    pp_value value
 
 let pp_set ppf set =
   Format.fprintf ppf "[@[<v>%a@]]"

--- a/src/compilerlib/pb_option.ml
+++ b/src/compilerlib/pb_option.ml
@@ -60,6 +60,11 @@ let empty = []
 let rec merge_value v1 v2 =
   match v1, v2 with
   | Message_literal ml1, Message_literal ml2 ->
+    (* In this case, both the existing and new values are messages.
+       Iterate through the fields of the new value.
+       For each field, check if a field with the same name exists in the existing value.
+       If it does and both field values are messages, merge them recursively.
+       If it does not, add the new field to the existing message. *)
     let rec merge_lists list1 list2 =
       match list2 with
       | [] -> list1
@@ -67,22 +72,33 @@ let rec merge_value v1 v2 =
         let updated_list, is_merged =
           List.fold_left
             (fun (acc, merged) (f, v) ->
-              if f = field then (
+              if String.equal f field then (
                 match value, v with
                 | Message_literal _, Message_literal _ ->
-                  acc @ [ f, merge_value value v ], true
+                  ( acc @ [ f, merge_value value v ],
+                    true (* recursively merges two message literals *) )
                 | _ -> acc @ [ f, value ], merged
               ) else
                 acc @ [ f, v ], merged)
             ([], false) list1
         in
         if is_merged then
+          (* If the current field of list2 was found in list1 and the two
+             values merged, continue with the rest of list2. The current field of
+             list2 is not added to updated_list as its value has already been
+             included during the merge. *)
           merge_lists updated_list rest
         else
+          (* If the current field of list2 was not found in list1, add it to
+             updated_list. *)
           merge_lists (updated_list @ [ field, value ]) rest
     in
     Message_literal (merge_lists ml1 ml2)
-  | _ -> v2 (* FIXME: This overrides an existing value, which is not allowed *)
+  | _ ->
+    (* FIXME: This overrides the scalar value of an existing option with the
+       scalar value of a new option, which is not allowed as per Protocol Buffer
+       Language Specification. *)
+    v2
 
 let add option_set option_name value =
   match
@@ -90,11 +106,17 @@ let add option_set option_name value =
       (fun ((name, _) : t) -> option_name_equal name option_name)
       option_set
   with
-  | [], _ -> (option_name, value) :: option_set
+  | [], _ ->
+    (* If the option does not currently exist in the set, add it *)
+    (option_name, value) :: option_set
   | [ (_, existing_value) ], remainder ->
+    (* If the option already exists in the set, merge it's value with the new value *)
     let merged_value = merge_value existing_value value in
     (option_name, merged_value) :: remainder
   | _ ->
+    (* This is a sanity check. As we use an equality function, List.partition should
+     * always partition the list into two lists where the first list has at most one element. 
+     * Hence, the condition that results in a call to failwith should never be satisfied. *)
     failwith
       "This should not happen, partition should result in at most single item \
        in left component"

--- a/src/compilerlib/pb_option.ml
+++ b/src/compilerlib/pb_option.ml
@@ -1,3 +1,28 @@
+(*
+  The MIT License (MIT)
+
+  Copyright (c) 2016 Maxime Ransan <maxime.ransan@gmail.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+
+*)
+
 type constant =
   | Constant_string of string
   | Constant_bool of bool
@@ -57,7 +82,7 @@ let rec merge_value v1 v2 =
           merge_lists (updated_list @ [ field, value ]) rest
     in
     Message_literal (merge_lists ml1 ml2)
-  | _ -> v2
+  | _ -> v2 (* FIXME: This overrides an existing value, which is not allowed *)
 
 let add option_set option_name value =
   match

--- a/src/compilerlib/pb_option.ml
+++ b/src/compilerlib/pb_option.ml
@@ -32,17 +32,6 @@ let option_name_equal a b =
 
 let empty = []
 
-let destructure_option_name option_name value =
-  List.fold_right
-    (fun name_part acc ->
-      match name_part with
-      | Simple_name name -> Message_literal [ name, acc ]
-      | Extension_name name ->
-        failwith
-          (Printf.sprintf "Extension_name '%s' is not supported in option_name"
-             name))
-    option_name value
-
 let rec merge_value v1 v2 =
   match v1, v2 with
   | Message_literal ml1, Message_literal ml2 ->

--- a/src/compilerlib/pb_option.mli
+++ b/src/compilerlib/pb_option.mli
@@ -34,10 +34,6 @@ val stringify_option_name : option_name -> string
 val empty : set
 val add : set -> option_name -> value -> set
 
-val merge : set -> set -> set
-(** [merge s1 s2] adds all the options from [s2] to [s1]. This means
-    than in case of duplicates [s2] options will override [s1] options. *)
-
 val get : set -> option_name -> value option
 val get_ext : set -> string -> value option
 val pp_constant : Format.formatter -> constant -> unit

--- a/src/compilerlib/pb_option.mli
+++ b/src/compilerlib/pb_option.mli
@@ -18,12 +18,10 @@ and value =
   | Message_literal of message_literal
   | List_literal of list_literal
 
-type name_part =
+(** Option identifier *)
+type option_name =
   | Simple_name of string
   | Extension_name of string
-
-type option_name = name_part list
-(** Option identifier *)
 
 type t = option_name * value
 

--- a/src/compilerlib/pb_option.mli
+++ b/src/compilerlib/pb_option.mli
@@ -1,4 +1,73 @@
-(** Protobuf File/Message/Field options *)
+(*
+  The MIT License (MIT)
+
+  Copyright (c) 2016 Maxime Ransan <maxime.ransan@gmail.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+
+*)
+
+(** Protobuf File/Message/Field options
+
+This module represents "compiled" option set, which is high level
+representation, as opposed to low-level representation in Pb_raw_option module.
+
+For the following "raw" set of options:
+
+{[
+  option (google.api.http).custom.kind = "FETCH";
+  option (google.api.http).custom.path = "/foo/bar/baz/{id}";
+  option (google.api.http).additional_bindings = {
+      get: "/foo/bar/baz/{id}"
+  };
+  option (google.api.http).additional_bindings = {
+      post: "/foo/bar/baz/"
+      body: "*"
+  };
+]}
+
+The "compiled" representation will have only one option [(google.api.http)],
+which is a message:
+
+{[
+  option (google.api.http) = {
+      custom: {
+          kind: "FETCH"
+          path: "/foo/bar/baz/{id}"
+      }
+      additional_bindings: [
+        {
+            get: "/foo/bar/baz/{id}"
+        },
+        {
+            post: "/foo/bar/baz/"
+            body: "*"
+        }
+      ]
+  };
+]}
+
+Option normalization is happening in [Pb_typing_validation.normalize_option],
+destructured field assigments are normalized back to nested messages. See
+[Pb_typing_validation.compile_option] to see the full process of option
+compilation.
+*)
 
 (** Protobuf constant
 
@@ -18,7 +87,7 @@ and value =
   | Message_literal of message_literal
   | List_literal of list_literal
 
-(** Option identifier *)
+(** Top level option name *)
 type option_name =
   | Simple_name of string
   | Extension_name of string
@@ -26,16 +95,24 @@ type option_name =
 type t = option_name * value
 
 type set = t list
-(** Collection of options
-
-    Can be used for field/message or file options *)
+(** Compiled collection of options *)
 
 val stringify_option_name : option_name -> string
 val empty : set
+
 val add : set -> option_name -> value -> set
+(** [add set name value] adds option [(name, value)] into the [set]. Option name
+and value are expected to be normalized (see
+[Pb_typing_validation.normalize_option]). [add] is merging nested message
+literals within option value with the ones that were previously added to the
+[set]. *)
 
 val get : set -> option_name -> value option
+
 val get_ext : set -> string -> value option
+(** [get_ext set name] is a helper that retrieves [Extension_name name] option
+from [set] *)
+
 val pp_constant : Format.formatter -> constant -> unit
 val pp_value : Format.formatter -> value -> unit
 val pp_message_literal : Format.formatter -> message_literal -> unit

--- a/src/compilerlib/pb_option.mli
+++ b/src/compilerlib/pb_option.mli
@@ -18,7 +18,11 @@ and value =
   | Message_literal of message_literal
   | List_literal of list_literal
 
-type option_name = string
+type name_part =
+  | Simple_name of string
+  | Extension_name of string
+
+type option_name = name_part list
 (** Option identifier *)
 
 type t = option_name * value
@@ -28,14 +32,16 @@ type set = t list
 
     Can be used for field/message or file options *)
 
+val stringify_option_name : option_name -> string
 val empty : set
-val add : set -> string -> value -> set
+val add : set -> option_name -> value -> set
 
 val merge : set -> set -> set
 (** [merge s1 s2] adds all the options from [s2] to [s1]. This means
     than in case of duplicates [s2] options will override [s1] options. *)
 
-val get : set -> string -> value option
+val get : set -> option_name -> value option
+val get_ext : set -> string -> value option
 val pp_constant : Format.formatter -> constant -> unit
 val pp_value : Format.formatter -> value -> unit
 val pp_message_literal : Format.formatter -> message_literal -> unit

--- a/src/compilerlib/pb_parsing_parse_tree.ml
+++ b/src/compilerlib/pb_parsing_parse_tree.ml
@@ -25,12 +25,6 @@
 
 (** Protobuf parse tree *)
 
-type option_name_part =
-  | Simple_name of string
-  | Extension_name of string
-
-type option_name = option_name_part list
-
 type message_field_label =
   [ `Optional
   | `Required
@@ -51,7 +45,7 @@ type 'a field = {
   field_number: int;
   field_label: 'a;
   field_type: Pb_field_type.unresolved_t;
-  field_options: Pb_option.set;
+  field_options: Pb_raw_option.set;
 }
 (** message field.
 
@@ -69,12 +63,12 @@ type map_field = {
   map_number: int;
   map_key_type: Pb_field_type.map_key_type;
   map_value_type: Pb_field_type.unresolved_t;
-  map_options: Pb_option.set;
+  map_options: Pb_raw_option.set;
 }
 
 type oneof_body_content =
   | Oneof_field of oneof_field
-  | Oneof_option of Pb_option.t
+  | Oneof_option of Pb_raw_option.t
 
 type oneof = {
   oneof_name: string;
@@ -85,12 +79,12 @@ type oneof = {
 type enum_value = {
   enum_value_name: string;
   enum_value_int: int;
-  enum_value_options: Pb_option.set;
+  enum_value_options: Pb_raw_option.set;
 }
 
 type enum_body_content =
   | Enum_value of enum_value
-  | Enum_option of Pb_option.t
+  | Enum_option of Pb_raw_option.t
 
 type enum = {
   enum_id: int;
@@ -119,7 +113,7 @@ type message_body_content =
   | Message_enum of enum
   | Message_extension of extension_range list
   | Message_reserved of extension_range list
-  | Message_option of Pb_option.t
+  | Message_option of Pb_raw_option.t
 
 and message = {
   id: int;
@@ -135,7 +129,7 @@ and message = {
 
 type rpc = {
   rpc_name: string;
-  rpc_options: Pb_option.set;
+  rpc_options: Pb_raw_option.set;
   rpc_req_stream: bool;
   rpc_req: Pb_field_type.unresolved_t;
   rpc_res_stream: bool;
@@ -144,7 +138,7 @@ type rpc = {
 
 type service_body_content =
   | Service_rpc of rpc
-  | Service_option of Pb_option.t
+  | Service_option of Pb_raw_option.t
 
 type service = {
   service_name: string;
@@ -166,7 +160,7 @@ type proto = {
   proto_file_name: string option;
   syntax: string option;
   imports: import list;
-  file_options: Pb_option.set;
+  file_options: Pb_raw_option.set;
   package: string option;
   messages: message list;
   services: service list;
@@ -203,7 +197,7 @@ let pp_field pp_label ppf field =
      field_options = %a;@,\
      }@]"
     field.field_name field.field_number pp_label field.field_label
-    Pb_field_type.pp_unresolved_t field.field_type Pb_option.pp_set
+    Pb_field_type.pp_unresolved_t field.field_type Pb_raw_option.pp_set
     field.field_options
 
 let pp_message_field ppf field = pp_field pp_message_field_label ppf field
@@ -220,11 +214,11 @@ let pp_map_field ppf map_field =
      }@]"
     map_field.map_name map_field.map_number Pb_field_type.pp_map_key_type
     map_field.map_key_type Pb_field_type.pp_unresolved_t
-    map_field.map_value_type Pb_option.pp_set map_field.map_options
+    map_field.map_value_type Pb_raw_option.pp_set map_field.map_options
 
 let pp_oneof_body_content ppf = function
   | Oneof_field field -> pp_oneof_field ppf field
-  | Oneof_option option -> Pb_option.pp_t ppf option
+  | Oneof_option option -> Pb_raw_option.pp_t ppf option
 
 let pp_oneof ppf oneof =
   fprintf ppf "{@[<v 2>%s = %S;@,%s = [@[<v>%a@]];@,@]}" "oneof_name"
@@ -241,7 +235,7 @@ let pp_enum_value ppf enum_value =
 let pp_enum_body_content ppf enum_body_content =
   match enum_body_content with
   | Enum_value enum_value -> pp_enum_value ppf enum_value
-  | Enum_option option -> Pb_option.pp_t ppf option
+  | Enum_option option -> Pb_raw_option.pp_t ppf option
 
 let pp_enum ppf enum =
   fprintf ppf
@@ -284,7 +278,7 @@ let rec pp_message_body_content ppf msg_body_content =
          ~pp_sep:(fun ppf () -> fprintf ppf ";@,")
          pp_extension_range)
       res_ranges
-  | Message_option option -> Pb_option.pp_t ppf option
+  | Message_option option -> Pb_raw_option.pp_t ppf option
 
 and pp_message ppf message =
   fprintf ppf
@@ -305,14 +299,14 @@ let pp_rpc ppf rpc =
      rpc_res_stream = %b;@,\
      rpc_res = %a;@,\
      }@]"
-    rpc.rpc_name Pb_option.pp_set rpc.rpc_options rpc.rpc_req_stream
+    rpc.rpc_name Pb_raw_option.pp_set rpc.rpc_options rpc.rpc_req_stream
     Pb_field_type.pp_unresolved_t rpc.rpc_req rpc.rpc_res_stream
     Pb_field_type.pp_unresolved_t rpc.rpc_res
 
 let rec pp_service_body_content ppf service_body_content =
   match service_body_content with
   | Service_rpc rpc -> pp_rpc ppf rpc
-  | Service_option option -> Pb_option.pp_t ppf option
+  | Service_option option -> Pb_raw_option.pp_t ppf option
 
 and pp_service ppf service =
   fprintf ppf "{@[<v 2>@,service_name = %S;@,service_body = [@[<v>%a@]];@,}@]"
@@ -350,7 +344,7 @@ let pp_proto ppf proto =
     (pp_print_option ~none:pp_none pp_print_string)
     proto.syntax
     (pp_print_list ~pp_sep:(fun ppf () -> fprintf ppf ";@,") pp_import)
-    proto.imports Pb_option.pp_set proto.file_options
+    proto.imports Pb_raw_option.pp_set proto.file_options
     (pp_print_option ~none:pp_none pp_print_string)
     proto.package
     (pp_print_list ~pp_sep:(fun ppf () -> fprintf ppf ";@,") pp_message)

--- a/src/compilerlib/pb_parsing_parse_tree.ml
+++ b/src/compilerlib/pb_parsing_parse_tree.ml
@@ -25,6 +25,12 @@
 
 (** Protobuf parse tree *)
 
+type option_name_part =
+  | Simple_name of string
+  | Extension_name of string
+
+type option_name = option_name_part list
+
 type message_field_label =
   [ `Optional
   | `Required

--- a/src/compilerlib/pb_parsing_parser.mly
+++ b/src/compilerlib/pb_parsing_parser.mly
@@ -240,7 +240,7 @@ rpc_options_list :
   }
 
 rpc_option :
-  | T_option option_identifier T_equal option_value semicolon { ($2, $4) }
+  | T_option option_identifier T_equal option_value semicolon { Pb_parsing_util.normalize_option $2 $4 }
 
 option_value :
   | constant { Pb_option.Scalar_value $1 }
@@ -359,7 +359,7 @@ field_option_list :
   }
 
 field_option :
-  | option_identifier T_equal option_value { ($1, $3) }
+  | option_identifier T_equal option_value { Pb_parsing_util.normalize_option $1 $3 }
 
 option_identifier_item :
   | T_ident                       {snd $1 |> Pb_parsing_util.option_name_of_ident}
@@ -370,7 +370,7 @@ option_identifier :
   | option_identifier_item option_identifier {$1 @ $2}
 
 option :
-  | T_option option_identifier T_equal option_value semicolon { ($2, $4) }
+  | T_option option_identifier T_equal option_value semicolon { Pb_parsing_util.normalize_option $2 $4}
 
 constant :
   | T_int        { Pb_option.Constant_int $1 }

--- a/src/compilerlib/pb_parsing_parser.mly
+++ b/src/compilerlib/pb_parsing_parser.mly
@@ -362,12 +362,12 @@ field_option :
   | option_identifier T_equal option_value { ($1, $3) }
 
 option_identifier_item :
-  | T_ident                   {snd $1}
-  | T_lparen T_ident T_rparen     {snd $2}
+  | T_ident                       {snd $1 |> Pb_parsing_util.option_name_of_ident}
+  | T_lparen T_ident T_rparen     {snd $2 |> Pb_parsing_util.option_name_extension}
 
 option_identifier :
   | option_identifier_item    {$1}
-  | option_identifier T_ident   {$1 ^ (snd $2)}
+  | option_identifier_item option_identifier {$1 @ $2}
 
 option :
   | T_option option_identifier T_equal option_value semicolon { ($2, $4) }

--- a/src/compilerlib/pb_parsing_parser.mly
+++ b/src/compilerlib/pb_parsing_parser.mly
@@ -359,9 +359,7 @@ field_option_list :
   }
 
 field_option :
-  | T_ident T_equal option_value               { (snd $1, $3) }
-  | T_lparen T_ident T_rparen T_equal option_value { (snd $2, $5)}
-  | T_lparen T_ident T_rparen T_ident T_equal option_value { ((snd $2) ^ (snd $4), $6)}
+  | option_identifier T_equal option_value { ($1, $3) }
 
 option_identifier_item :
   | T_ident                   {snd $1}

--- a/src/compilerlib/pb_parsing_parser.mly
+++ b/src/compilerlib/pb_parsing_parser.mly
@@ -68,7 +68,7 @@
 /*Entry points*/
 
 %start field_options_
-%type <Pb_option.set> field_options_
+%type <Pb_raw_option.set> field_options_
 %start normal_field_
 %type <Pb_parsing_parse_tree.message_field> normal_field_
 %start enum_value_
@@ -86,7 +86,7 @@
 %start import_
 %type <Pb_parsing_parse_tree.import> import_
 %start option_
-%type <Pb_option.t> option_
+%type <Pb_raw_option.t> option_
 %start extension_range_list_
 %type <Pb_parsing_parse_tree.extension_range list> extension_range_list_
 %start extension_
@@ -129,7 +129,7 @@ proto:
 
 proto_content:
   | import              {Pb_parsing_util.proto ~import:$1  ()}
-  | option              {Pb_parsing_util.proto ~file_option:$1  ()}
+  | option              { (let x : Pb_raw_option.t = $1 in Pb_parsing_util.proto ~file_option:x  ())}
   | package_declaration {Pb_parsing_util.proto ~package:$1 ()}
   | message             {Pb_parsing_util.proto ~message:$1 ()}
   | service             {Pb_parsing_util.proto ~service:$1 ()}
@@ -227,20 +227,20 @@ rpc :
 rpc_options :
   | T_lbrace rpc_options_list T_rbrace           { $2 }
   | T_lbrace rpc_options_list T_rbrace semicolon { $2 }
-  | T_lbrace T_rbrace                            { Pb_option.empty }
-  | T_lbrace T_rbrace semicolon                  { Pb_option.empty };
+  | T_lbrace T_rbrace                            { Pb_raw_option.empty }
+  | T_lbrace T_rbrace semicolon                  { Pb_raw_option.empty };
 
 rpc_options_list :
   | rpc_option                          {
     let option_name, option_value = $1 in
-    Pb_option.add Pb_option.empty option_name option_value
+    Pb_raw_option.add Pb_raw_option.empty option_name option_value
   }
   | rpc_option rpc_options_list  {
-    Pb_option.add $2 (fst $1) (snd $1)
+    Pb_raw_option.add $2 (fst $1) (snd $1)
   }
 
 rpc_option :
-  | T_option option_identifier T_equal option_value semicolon { Pb_parsing_util.normalize_option $2 $4 }
+  | T_option option_identifier T_equal option_value semicolon { ($2, $4) }
 
 option_value :
   | constant { Pb_option.Scalar_value $1 }
@@ -347,19 +347,19 @@ label :
 
 field_options :
   | T_lbracket field_option_list T_rbracket { $2 }
-  | T_lbracket T_rbracket                   { Pb_option.empty };
+  | T_lbracket T_rbracket                   { Pb_raw_option.empty };
 
 field_option_list :
   | field_option                          {
     let option_name, option_value = $1 in
-    Pb_option.add Pb_option.empty option_name option_value
+    Pb_raw_option.add Pb_raw_option.empty option_name option_value
   }
   | field_option T_comma field_option_list  {
-    Pb_option.add $3 (fst $1) (snd $1)
+    Pb_raw_option.add $3 (fst $1) (snd $1)
   }
 
 field_option :
-  | option_identifier T_equal option_value { Pb_parsing_util.normalize_option $1 $3 }
+  | option_identifier T_equal option_value { ($1, $3) }
 
 option_identifier_item :
   | T_ident                       {snd $1 |> Pb_parsing_util.option_name_of_ident}
@@ -370,7 +370,7 @@ option_identifier :
   | option_identifier_item option_identifier {$1 @ $2}
 
 option :
-  | T_option option_identifier T_equal option_value semicolon { Pb_parsing_util.normalize_option $2 $4}
+  | T_option option_identifier T_equal option_value semicolon { (let foo: Pb_raw_option.t = ($2, $4) in foo) }
 
 constant :
   | T_int        { Pb_option.Constant_int $1 }

--- a/src/compilerlib/pb_parsing_util.ml
+++ b/src/compilerlib/pb_parsing_util.ml
@@ -26,7 +26,7 @@
 module E = Pb_exception
 module Pt = Pb_parsing_parse_tree
 
-let field ?(options = Pb_option.empty) ~label ~number ~type_ name =
+let field ?(options = Pb_raw_option.empty) ~label ~number ~type_ name =
   {
     Pt.field_name = name;
     Pt.field_number = number;
@@ -35,7 +35,7 @@ let field ?(options = Pb_option.empty) ~label ~number ~type_ name =
     Pt.field_options = options;
   }
 
-let map_field ?options:(map_options = Pb_option.empty) ~number ~key_type
+let map_field ?options:(map_options = Pb_raw_option.empty) ~number ~key_type
     ~value_type name =
   let map_key_type =
     Pb_field_type.parse key_type |> function
@@ -54,7 +54,7 @@ let map_field ?options:(map_options = Pb_option.empty) ~number ~key_type
     Pt.map_options;
   }
 
-let oneof_field ?(options = Pb_option.empty) ~number ~type_ name =
+let oneof_field ?(options = Pb_raw_option.empty) ~number ~type_ name =
   Pt.Oneof_field
     {
       Pt.field_name = name;
@@ -68,7 +68,7 @@ let oneof_option option_ = Pt.Oneof_option option_
 let oneof ?(oneof_body = []) name = { Pt.oneof_name = name; Pt.oneof_body }
 let message_counter = ref 0
 
-let enum_value ~int_value ?(options = Pb_option.empty) name =
+let enum_value ~int_value ?(options = Pb_raw_option.empty) name =
   Pt.(
     Enum_value
       {
@@ -114,8 +114,8 @@ let message ~content message_name =
 let service_body_option option_ = Pt.Service_option option_
 let service_body_rpc rpc = Pt.Service_rpc rpc
 
-let rpc ?(options = Pb_option.empty) ~req_stream ~req ~res_stream ~res rpc_name
-    =
+let rpc ?(options = Pb_raw_option.empty) ~req_stream ~req ~res_stream ~res
+    rpc_name =
   Pt.
     {
       rpc_name;
@@ -136,34 +136,36 @@ let option_name_of_ident ident =
     else
       ident
   in
-  ident |> String.split_on_char '.' |> List.map (fun x -> Pt.Simple_name x)
+  ident |> String.split_on_char '.'
+  |> List.map (fun x -> Pb_raw_option.Simple_name x)
 
-let option_name_extension ident = [ Pt.Extension_name ident ]
+let option_name_extension ident = [ Pb_raw_option.Extension_name ident ]
 
-let normalize_option_name option_name value =
-  List.fold_right
-    (fun name_part acc ->
-      match name_part with
-      | Pt.Simple_name name -> Pb_option.Message_literal [ name, acc ]
-      | Pt.Extension_name name ->
-        failwith
-          (Printf.sprintf
-             "normalize_option_name: Extension_name '%s' is not supported in \
-              option_name"
-             name))
-    option_name value
+(* let normalize_option_name option_name value =
+     List.fold_right
+       (fun name_part acc ->
+         match name_part with
+         | Pb_raw_option.Simple_name name ->
+           Pb_option.Message_literal [ name, acc ]
+         | Pb_raw_option.Extension_name name ->
+           failwith
+             (Printf.sprintf
+                "normalize_option_name: Extension_name '%s' is not supported in \
+                 option_name"
+                name))
+       option_name value
 
-let option_name_from_part = function
-  | Pt.Simple_name x -> Pb_option.Simple_name x
-  | Pt.Extension_name x -> Pb_option.Extension_name x
+    let option_name_from_part = function
+     | Pb_raw_option.Simple_name x -> Pb_option.Simple_name x
+     | Pb_raw_option.Extension_name x -> Pb_option.Extension_name x
 
-let normalize_option option_name value =
-  match option_name with
-  | [] -> failwith "option_name can't be an empty list!"
-  | [ single_item ] -> option_name_from_part single_item, value
-  | top_level_item :: rest ->
-    let new_value = normalize_option_name rest value in
-    option_name_from_part top_level_item, new_value
+   let normalize_option option_name value =
+     match option_name with
+     | [] -> failwith "option_name can't be an empty list!"
+     | [ single_item ] -> option_name_from_part single_item, value
+     | top_level_item :: rest ->
+       let new_value = normalize_option_name rest value in
+       option_name_from_part top_level_item, new_value *)
 
 let service ~content service_name = Pt.{ service_name; service_body = content }
 
@@ -221,7 +223,7 @@ let proto ?syntax ?file_option ?package ?import ?message ?service ?enum ?proto
           package = None;
           messages = [];
           services = [];
-          file_options = Pb_option.empty;
+          file_options = Pb_raw_option.empty;
           enums = [];
           extends = [];
         }
@@ -272,7 +274,7 @@ let proto ?syntax ?file_option ?package ?import ?message ?service ?enum ?proto
     match file_option with
     | None -> proto
     | Some i ->
-      let file_options = Pb_option.add file_options (fst i) (snd i) in
+      let file_options = Pb_raw_option.add file_options (fst i) (snd i) in
       Pt.{ proto with file_options }
   in
 
@@ -312,7 +314,7 @@ let finalize_syntax3 proto =
      in messages. Optional is now allowed, but default values might
      not be. *)
   let verify_no_default_field_options field_name message_name field_options =
-    match Pb_option.get field_options (Pb_option.Simple_name "default") with
+    match Pb_raw_option.get field_options [ Simple_name "default" ] with
     | None -> ()
     | Some _ -> E.default_field_option_not_supported ~field_name ~message_name
   in
@@ -352,8 +354,8 @@ let finalize_syntax3 proto =
                 | #Pb_field_type.builtin_type_floating_point
                 | `Bool ->
                   let field_options =
-                    Pb_option.(
-                      add field_options (Pb_option.Simple_name "packed")
+                    Pb_raw_option.(
+                      add field_options [ Simple_name "packed" ]
                         (Scalar_value (Constant_bool true)))
                   in
                   { field with Pt.field_options }

--- a/src/compilerlib/pb_parsing_util.ml
+++ b/src/compilerlib/pb_parsing_util.ml
@@ -140,33 +140,6 @@ let option_name_of_ident ident =
   |> List.map (fun x -> Pb_raw_option.Simple_name x)
 
 let option_name_extension ident = [ Pb_raw_option.Extension_name ident ]
-
-(* let normalize_option_name option_name value =
-     List.fold_right
-       (fun name_part acc ->
-         match name_part with
-         | Pb_raw_option.Simple_name name ->
-           Pb_option.Message_literal [ name, acc ]
-         | Pb_raw_option.Extension_name name ->
-           failwith
-             (Printf.sprintf
-                "normalize_option_name: Extension_name '%s' is not supported in \
-                 option_name"
-                name))
-       option_name value
-
-    let option_name_from_part = function
-     | Pb_raw_option.Simple_name x -> Pb_option.Simple_name x
-     | Pb_raw_option.Extension_name x -> Pb_option.Extension_name x
-
-   let normalize_option option_name value =
-     match option_name with
-     | [] -> failwith "option_name can't be an empty list!"
-     | [ single_item ] -> option_name_from_part single_item, value
-     | top_level_item :: rest ->
-       let new_value = normalize_option_name rest value in
-       option_name_from_part top_level_item, new_value *)
-
 let service ~content service_name = Pt.{ service_name; service_body = content }
 
 let import ?public file_name =

--- a/src/compilerlib/pb_parsing_util.mli
+++ b/src/compilerlib/pb_parsing_util.mli
@@ -33,7 +33,7 @@ module Pt = Pb_parsing_parse_tree
 (** {2 Creators } *)
 
 val field :
-  ?options:Pb_option.set ->
+  ?options:Pb_raw_option.set ->
   label:Pt.message_field_label ->
   number:int ->
   type_:string ->
@@ -41,7 +41,7 @@ val field :
   Pt.message_field
 
 val map_field :
-  ?options:Pb_option.set ->
+  ?options:Pb_raw_option.set ->
   number:int ->
   key_type:string ->
   value_type:string ->
@@ -49,22 +49,22 @@ val map_field :
   Pt.map_field
 
 val oneof_field :
-  ?options:Pb_option.set ->
+  ?options:Pb_raw_option.set ->
   number:int ->
   type_:string ->
   string ->
   Pt.oneof_body_content
 
-val oneof_option : Pb_option.t -> Pt.oneof_body_content
+val oneof_option : Pb_raw_option.t -> Pt.oneof_body_content
 val oneof : ?oneof_body:Pt.oneof_body_content list -> string -> Pt.oneof
 val message_body_field : Pt.message_field -> Pt.message_body_content
 val message_body_map_field : Pt.map_field -> Pt.message_body_content
 val message_body_oneof_field : Pt.oneof -> Pt.message_body_content
 
 val enum_value :
-  int_value:int -> ?options:Pb_option.set -> string -> Pt.enum_body_content
+  int_value:int -> ?options:Pb_raw_option.set -> string -> Pt.enum_body_content
 
-val enum_option : Pb_option.t -> Pt.enum_body_content
+val enum_option : Pb_raw_option.t -> Pt.enum_body_content
 val enum : ?enum_body:Pt.enum_body_content list -> string -> Pt.enum
 val extension_range_single_number : int -> Pt.extension_range
 
@@ -75,11 +75,11 @@ val message_body_sub : Pt.message -> Pt.message_body_content
 val message_body_enum : Pt.enum -> Pt.message_body_content
 val message_body_extension : Pt.extension_range list -> Pt.message_body_content
 val message_body_reserved : Pt.extension_range list -> Pt.message_body_content
-val message_body_option : Pb_option.t -> Pt.message_body_content
+val message_body_option : Pb_raw_option.t -> Pt.message_body_content
 val message : content:Pt.message_body_content list -> string -> Pt.message
 
 val rpc :
-  ?options:Pb_option.set ->
+  ?options:Pb_raw_option.set ->
   req_stream:bool ->
   req:string ->
   res_stream:bool ->
@@ -89,15 +89,9 @@ val rpc :
 
 val option_map : Pb_option.message_literal -> Pb_option.value
 val option_list : Pb_option.list_literal -> Pb_option.value
-val option_name_of_ident : string -> Pt.option_name
-val option_name_extension : string -> Pt.option_name
-
-val normalize_option :
-  Pt.option_name_part list ->
-  Pb_option.value ->
-  Pb_option.option_name * Pb_option.value
-
-val service_body_option : Pb_option.t -> Pt.service_body_content
+val option_name_of_ident : string -> Pb_raw_option.option_name
+val option_name_extension : string -> Pb_raw_option.option_name
+val service_body_option : Pb_raw_option.t -> Pt.service_body_content
 val service_body_rpc : Pt.rpc -> Pt.service_body_content
 val service : content:Pt.service_body_content list -> string -> Pt.service
 val import : ?public:unit -> string -> Pt.import
@@ -105,7 +99,7 @@ val extend : string -> Pt.message_field list -> Pt.extend
 
 val proto :
   ?syntax:string ->
-  ?file_option:Pb_option.t ->
+  ?file_option:Pb_raw_option.t ->
   ?package:string ->
   ?import:Pt.import ->
   ?message:Pt.message ->

--- a/src/compilerlib/pb_parsing_util.mli
+++ b/src/compilerlib/pb_parsing_util.mli
@@ -89,8 +89,14 @@ val rpc :
 
 val option_map : Pb_option.message_literal -> Pb_option.value
 val option_list : Pb_option.list_literal -> Pb_option.value
-val option_name_of_ident : string -> Pb_option.option_name
-val option_name_extension : string -> Pb_option.option_name
+val option_name_of_ident : string -> Pt.option_name
+val option_name_extension : string -> Pt.option_name
+
+val normalize_option :
+  Pt.option_name_part list ->
+  Pb_option.value ->
+  Pb_option.option_name * Pb_option.value
+
 val service_body_option : Pb_option.t -> Pt.service_body_content
 val service_body_rpc : Pt.rpc -> Pt.service_body_content
 val service : content:Pt.service_body_content list -> string -> Pt.service

--- a/src/compilerlib/pb_parsing_util.mli
+++ b/src/compilerlib/pb_parsing_util.mli
@@ -89,6 +89,8 @@ val rpc :
 
 val option_map : Pb_option.message_literal -> Pb_option.value
 val option_list : Pb_option.list_literal -> Pb_option.value
+val option_name_of_ident : string -> Pb_option.option_name
+val option_name_extension : string -> Pb_option.option_name
 val service_body_option : Pb_option.t -> Pt.service_body_content
 val service_body_rpc : Pt.rpc -> Pt.service_body_content
 val service : content:Pt.service_body_content list -> string -> Pt.service

--- a/src/compilerlib/pb_raw_option.ml
+++ b/src/compilerlib/pb_raw_option.ml
@@ -1,3 +1,28 @@
+(*
+  The MIT License (MIT)
+
+  Copyright (c) 2016 Maxime Ransan <maxime.ransan@gmail.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+
+*)
+
 type name_part = Pb_option.option_name =
   | Simple_name of string
   | Extension_name of string

--- a/src/compilerlib/pb_raw_option.ml
+++ b/src/compilerlib/pb_raw_option.ml
@@ -1,0 +1,47 @@
+type name_part = Pb_option.option_name =
+  | Simple_name of string
+  | Extension_name of string
+
+type option_name = name_part list
+type t = option_name * Pb_option.value
+type set = t list
+
+let stringify_option_name name =
+  name
+  |> List.map (function
+       | Simple_name s -> s
+       | Extension_name s -> "(" ^ s ^ ")")
+  |> String.concat "."
+
+let option_name_part_equal a b =
+  match a, b with
+  | Simple_name a, Simple_name b -> String.equal a b
+  | Extension_name a, Extension_name b -> String.equal a b
+  | _ -> false
+
+let option_name_equal = List.equal option_name_part_equal
+let empty = []
+let add option_set option_name value = (option_name, value) :: option_set
+
+let merge set1 set2 =
+  List.fold_left
+    (fun acc (option_name, value) -> add acc option_name value)
+    set1 set2
+
+let get t option_name =
+  match List.find (fun (other, _) -> option_name_equal option_name other) t with
+  | _, c -> Some c
+  | exception Not_found -> None
+
+let get_ext t option_name = get t [ Extension_name option_name ]
+let get_simple t option_name = get t [ Simple_name option_name ]
+
+let pp_t ppf (name, value) =
+  Format.fprintf ppf "{@;<1 2>%S: %a@;<1 2>}"
+    (stringify_option_name name)
+    Pb_option.pp_value value
+
+let pp_set ppf set =
+  Format.fprintf ppf "[@[<v>%a@]]"
+    (Format.pp_print_list ~pp_sep:(fun ppf () -> Format.fprintf ppf ",@,") pp_t)
+    set

--- a/src/compilerlib/pb_raw_option.ml
+++ b/src/compilerlib/pb_raw_option.ml
@@ -23,11 +23,6 @@ let option_name_equal = List.equal option_name_part_equal
 let empty = []
 let add option_set option_name value = (option_name, value) :: option_set
 
-let merge set1 set2 =
-  List.fold_left
-    (fun acc (option_name, value) -> add acc option_name value)
-    set1 set2
-
 let get t option_name =
   match List.find (fun (other, _) -> option_name_equal option_name other) t with
   | _, c -> Some c
@@ -42,6 +37,13 @@ let assoc_option_name key alist =
 
 let remove_assoc_option_name key alist =
   List.filter (fun (k, _) -> not (option_name_equal k key)) alist
+
+let merge set1 set2 =
+  List.fold_left
+    (fun acc (option_name, value) ->
+      let acc = remove_assoc_option_name option_name acc in
+      add acc option_name value)
+    set1 set2
 
 let group_list_values (set : set) : set =
   let rec aux grouped = function

--- a/src/compilerlib/pb_raw_option.mli
+++ b/src/compilerlib/pb_raw_option.mli
@@ -1,0 +1,23 @@
+(** Protobuf File/Message/Field raw options (i.e. exactly as they parsed) *)
+
+type name_part =
+  | Simple_name of string
+  | Extension_name of string
+
+type option_name = name_part list
+type t = option_name * Pb_option.value
+type set = t list
+
+val stringify_option_name : option_name -> string
+val empty : set
+val add : set -> option_name -> Pb_option.value -> set
+
+val merge : set -> set -> set
+(** [merge s1 s2] adds all the options from [s2] to [s1]. This means
+    than in case of duplicates [s2] options will override [s1] options. *)
+
+val get : set -> option_name -> Pb_option.value option
+val get_ext : set -> string -> Pb_option.value option
+val get_simple : set -> string -> Pb_option.value option
+val pp_t : Format.formatter -> t -> unit
+val pp_set : Format.formatter -> set -> unit

--- a/src/compilerlib/pb_raw_option.mli
+++ b/src/compilerlib/pb_raw_option.mli
@@ -19,5 +19,6 @@ val merge : set -> set -> set
 val get : set -> option_name -> Pb_option.value option
 val get_ext : set -> string -> Pb_option.value option
 val get_simple : set -> string -> Pb_option.value option
+val group_list_values : set -> set
 val pp_t : Format.formatter -> t -> unit
 val pp_set : Format.formatter -> set -> unit

--- a/src/compilerlib/pb_raw_option.mli
+++ b/src/compilerlib/pb_raw_option.mli
@@ -1,4 +1,56 @@
+(*
+  The MIT License (MIT)
+
+  Copyright (c) 2016 Maxime Ransan <maxime.ransan@gmail.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+
+*)
+
 (** Protobuf File/Message/Field raw options (i.e. exactly as they parsed) *)
+
+(*
+Option names in Protobuf are complicated. See their syntax definition:
+
+
+OptionName = ( SimpleName | ExtensionName ) [ dot OptionName ] .
+
+SimpleName    = identifier .
+ExtensionName = l_paren TypeName r_paren
+
+
+
+Example of option names are below:
+
+deprecated
+json_name
+(foo.bar)
+abc.def.xyz
+(foo).bar.(.baz.bob)
+
+
+This module is low-level, it tracks list of options as they were parsed, option
+name is a list of parts according to syntax specification. Option can be present
+multiple times, which means it's a destructured list (see [group_list_values]).
+
+Good read on Protobuf options: https://github.com/bufbuild/protobuf-language-spec/blob/main/language-spec.md#options
+*)
 
 type name_part =
   | Simple_name of string
@@ -19,6 +71,38 @@ val merge : set -> set -> set
 val get : set -> option_name -> Pb_option.value option
 val get_ext : set -> string -> Pb_option.value option
 val get_simple : set -> string -> Pb_option.value option
+
 val group_list_values : set -> set
+(** [group_list_values set] groups options with the same name into Pb_option.List_literal
+
+The following set of options:
+
+{[
+  option (google.api.http).additional_bindings = {
+      get: "/foo/bar/baz/{id}"
+  };
+  option (google.api.http).additional_bindings = {
+      post: "/foo/bar/baz/"
+      body: "*"
+  };
+]}
+
+Is equivalent to the below non-destructured version:
+
+{[
+  option (google.api.http) = {
+      additional_bindings: [
+        {
+            get: "/foo/bar/baz/{id}"
+        },
+        {
+            post: "/foo/bar/baz/"
+            body: "*"
+        }
+      ]
+  };
+]}
+*)
+
 val pp_t : Format.formatter -> t -> unit
 val pp_set : Format.formatter -> set -> unit

--- a/src/compilerlib/pb_typing_util.mli
+++ b/src/compilerlib/pb_typing_util.mli
@@ -50,7 +50,8 @@ val field_default : ('a, 'b) Tt.field -> Pb_option.constant option
 
 val field_options : ('a, 'b) Tt.field -> Pb_option.set
 
-val field_option : ('a, 'b) Tt.field -> string -> Pb_option.value option
+val field_option :
+  ('a, 'b) Tt.field -> Pb_option.option_name -> Pb_option.value option
 (** [field_option field option_name] returns the constant associated with
     [option_name]. If the fields options does not contain [option_name] [None]
     is returned.
@@ -62,8 +63,11 @@ val type_of_id : 'a Tt.proto_type list -> int -> 'a Tt.proto_type
   *)
 
 val string_of_message : int -> Tt.type_scope -> 'a Tt.message -> string
-val message_option : 'a Tt.message -> string -> Pb_option.value option
-val enum_option : Tt.enum -> string -> Pb_option.value option
+
+val message_option :
+  'a Tt.message -> Pb_option.option_name -> Pb_option.value option
+
+val enum_option : Tt.enum -> Pb_option.option_name -> Pb_option.value option
 
 (** {2 Accessor for Tt.type} *)
 

--- a/src/compilerlib/pb_typing_validation.ml
+++ b/src/compilerlib/pb_typing_validation.ml
@@ -37,7 +37,7 @@ let scope_of_package : string option -> Tt.type_scope = function
   | None -> Typing_util.empty_scope
 
 let get_default field_name field_options : Pb_option.constant option =
-  match Pb_option.get field_options (Pb_option.Simple_name "default") with
+  match Pb_raw_option.get_simple field_options "default" with
   | Some (Pb_option.Scalar_value constant) -> Some constant
   | Some (Pb_option.Message_literal _) ->
     E.invalid_default_value ~field_name

--- a/src/compilerlib/pb_typing_validation.ml
+++ b/src/compilerlib/pb_typing_validation.ml
@@ -37,7 +37,7 @@ let scope_of_package : string option -> Tt.type_scope = function
   | None -> Typing_util.empty_scope
 
 let get_default field_name field_options : Pb_option.constant option =
-  match Pb_option.get field_options "default" with
+  match Pb_option.get field_options [ Pb_option.Simple_name "default" ] with
   | Some (Pb_option.Scalar_value constant) -> Some constant
   | Some (Pb_option.Message_literal _) ->
     E.invalid_default_value ~field_name

--- a/src/compilerlib/pb_typing_validation.ml
+++ b/src/compilerlib/pb_typing_validation.ml
@@ -37,7 +37,7 @@ let scope_of_package : string option -> Tt.type_scope = function
   | None -> Typing_util.empty_scope
 
 let get_default field_name field_options : Pb_option.constant option =
-  match Pb_option.get field_options [ Pb_option.Simple_name "default" ] with
+  match Pb_option.get field_options (Pb_option.Simple_name "default") with
   | Some (Pb_option.Scalar_value constant) -> Some constant
   | Some (Pb_option.Message_literal _) ->
     E.invalid_default_value ~field_name

--- a/src/compilerlib/pb_typing_validation.mli
+++ b/src/compilerlib/pb_typing_validation.mli
@@ -44,7 +44,6 @@ val validate : Pt.proto -> Pb_field_type.unresolved Tt.proto
 (** {2 Testing Only} *)
 
 val validate_message :
-  ?parent_options:Pb_option.set ->
   string ->
   Pb_option.set ->
   (* file options *)

--- a/src/ocaml-protoc/ocaml_protoc_cmdline.ml
+++ b/src/ocaml-protoc/ocaml_protoc_cmdline.ml
@@ -87,15 +87,17 @@ module File_options = struct
         let option_name, option_value = f x in
         Pb_option.add options option_name option_value
     in
-    Pb_option.empty
+    let open Pb_option in
+    empty
     |> map int32_type (fun s ->
-           "int32_type", Pb_option.(Scalar_value (Constant_literal s)))
+           [ Extension_name "int32_type" ], Scalar_value (Constant_literal s))
     |> map int64_type (fun s ->
-           "int64_type", Pb_option.(Scalar_value (Constant_literal s)))
+           [ Extension_name "int64_type" ], Scalar_value (Constant_literal s))
     |> map ocaml_file_ppx (fun s ->
-           "ocaml_file_ppx", Pb_option.(Scalar_value (Constant_string s)))
+           [ Extension_name "ocaml_file_ppx" ], Scalar_value (Constant_string s))
     |> map ocaml_all_types_ppx (fun s ->
-           "ocaml_all_types_ppx", Pb_option.(Scalar_value (Constant_string s)))
+           ( [ Extension_name "ocaml_all_types_ppx" ],
+             Scalar_value (Constant_string s) ))
 end
 
 (** Command line argument for the ocaml-protoc *)

--- a/src/ocaml-protoc/ocaml_protoc_cmdline.ml
+++ b/src/ocaml-protoc/ocaml_protoc_cmdline.ml
@@ -77,7 +77,7 @@ module File_options = struct
 
   (** Converts the command line values to Parse Tree file options
     *)
-  let to_file_options t : Pb_option.set =
+  let to_file_options t : Pb_raw_option.set =
     let { int32_type; int64_type; ocaml_file_ppx; ocaml_all_types_ppx } = t in
 
     let map x f options =
@@ -85,18 +85,18 @@ module File_options = struct
       | None -> options
       | Some x ->
         let option_name, option_value = f x in
-        Pb_option.add options option_name option_value
+        Pb_raw_option.add options option_name option_value
     in
-    let open Pb_option in
+    let open Pb_raw_option in
     empty
     |> map int32_type (fun s ->
-           Extension_name "int32_type", Scalar_value (Constant_literal s))
+           [ Extension_name "int32_type" ], Scalar_value (Constant_literal s))
     |> map int64_type (fun s ->
-           Extension_name "int64_type", Scalar_value (Constant_literal s))
+           [ Extension_name "int64_type" ], Scalar_value (Constant_literal s))
     |> map ocaml_file_ppx (fun s ->
-           Extension_name "ocaml_file_ppx", Scalar_value (Constant_string s))
+           [ Extension_name "ocaml_file_ppx" ], Scalar_value (Constant_string s))
     |> map ocaml_all_types_ppx (fun s ->
-           ( Extension_name "ocaml_all_types_ppx",
+           ( [ Extension_name "ocaml_all_types_ppx" ],
              Scalar_value (Constant_string s) ))
 end
 

--- a/src/ocaml-protoc/ocaml_protoc_cmdline.ml
+++ b/src/ocaml-protoc/ocaml_protoc_cmdline.ml
@@ -90,13 +90,13 @@ module File_options = struct
     let open Pb_option in
     empty
     |> map int32_type (fun s ->
-           [ Extension_name "int32_type" ], Scalar_value (Constant_literal s))
+           Extension_name "int32_type", Scalar_value (Constant_literal s))
     |> map int64_type (fun s ->
-           [ Extension_name "int64_type" ], Scalar_value (Constant_literal s))
+           Extension_name "int64_type", Scalar_value (Constant_literal s))
     |> map ocaml_file_ppx (fun s ->
-           [ Extension_name "ocaml_file_ppx" ], Scalar_value (Constant_string s))
+           Extension_name "ocaml_file_ppx", Scalar_value (Constant_string s))
     |> map ocaml_all_types_ppx (fun s ->
-           ( [ Extension_name "ocaml_all_types_ppx" ],
+           ( Extension_name "ocaml_all_types_ppx",
              Scalar_value (Constant_string s) ))
 end
 

--- a/src/ocaml-protoc/ocaml_protoc_compilation.ml
+++ b/src/ocaml-protoc/ocaml_protoc_compilation.ml
@@ -76,7 +76,7 @@ let compile cmdline cmd_line_files_options : Ot.proto * _ =
         {
           proto with
           Pt.file_options =
-            Pb_option.merge proto.Pt.file_options cmd_line_files_options;
+            Pb_raw_option.merge proto.Pt.file_options cmd_line_files_options;
         })
       protos
   in

--- a/src/ocaml-protoc/ocaml_protoc_generation.mli
+++ b/src/ocaml-protoc/ocaml_protoc_generation.mli
@@ -4,4 +4,4 @@ module Ot = Pb_codegen_ocaml_type
 module Cmdline = Ocaml_protoc_cmdline.Cmdline
 
 val generate_code :
-  Ot.proto -> proto_file_options:Pb_option.set -> Cmdline.t -> unit
+  Ot.proto -> proto_file_options:Pb_raw_option.set -> Cmdline.t -> unit

--- a/src/tests/expectation/option_processing.ml.expected
+++ b/src/tests/expectation/option_processing.ml.expected
@@ -25,6 +25,8 @@ and person = {
   id : person_id option;
 }
 
+type destructured_options = unit
+
 let rec default_payment_system () = (Cash:payment_system)
 
 let rec default_person_location 
@@ -52,6 +54,8 @@ and default_person
   picture;
   id;
 }
+
+let rec default_destructured_options = ()
 
 [@@@ocaml.warning "-27-30-39"]
 
@@ -102,9 +106,7 @@ and default_person
    "(validate.rules)": {"double": {"gte": -180,
                                    "lte": 180}}
    }]
-  Options: [{
-   "(validate.disabled)": true
-   }]
+  Options: []
 *)
 
 (* ----------------------------------------------------- *)
@@ -171,5 +173,18 @@ and default_person
    }]
   Options: [{
    "(validate.disabled)": true
+   }]
+*)
+
+(* ----------------------------------------------------- *)
+(*
+  Module Prefix: Option_processing
+  Empty Record: destructured_options
+  Options: [{
+   "(google.api.http)": {"custom": {"path": "/foo/bar/baz/{id}",
+                                    "kind": "FETCH"},
+                         "additional_bindings": [{"post": "/foo/bar/baz/",
+                                                  "body": "*"},
+                                                 {"get": "/foo/bar/baz/{id}"}]}
    }]
 *)

--- a/src/tests/expectation/option_processing.ml.expected
+++ b/src/tests/expectation/option_processing.ml.expected
@@ -63,17 +63,27 @@ and default_person
   Const Variant: payment_system
     Constructor: Cash
       Binary Value: 0, String Value: CASH
-      Options: {"label": Constant_string "Cash"}
+      Options: [{
+   "(label)": "Cash"
+   }]
     Constructor: Credit_card
       Binary Value: 1, String Value: CREDIT_CARD
-      Options: {"label": Constant_string "Credit Card"}
+      Options: [{
+   "(label)": "Credit Card"
+   }]
     Constructor: Debit_card
       Binary Value: 2, String Value: DEBIT_CARD
-      Options: {"label": Constant_string "Debit Card"}
+      Options: [{
+   "(label)": "Debit Card"
+   }]
     Constructor: App
       Binary Value: 3, String Value: APP
-      Options: {"label": Constant_string "Mobile App"}
-  Options: {"label": Constant_string "Payment method"}
+      Options: [{
+   "(label)": "Mobile App"
+   }]
+  Options: [{
+   "(label)": "Payment method"
+   }]
 *)
 
 (* ----------------------------------------------------- *)
@@ -82,11 +92,19 @@ and default_person
   Record: person_location
   - Field: lat
     Rft_nolabel (Field Type: Ft_basic_type: Bt_float, Encoding: 1, Payload Kind: Pk_bits64)
-    Field options: {"validate.rules.double": {"gte": Constant_int -90, "lte": Constant_int 90}}
+    Field options: [{
+   "(validate.rules).double": {"gte": -90,
+                               "lte": 90}
+   }]
   - Field: lng
     Rft_nolabel (Field Type: Ft_basic_type: Bt_float, Encoding: 2, Payload Kind: Pk_bits64)
-    Field options: {"validate.rules.double": {"gte": Constant_int -180, "lte": Constant_int 180}}
-  Options: {"validate.disabled": Constant_bool true}
+    Field options: [{
+   "(validate.rules).double": {"gte": -180,
+                               "lte": 180}
+   }]
+  Options: [{
+   "(validate.disabled)": true
+   }]
 *)
 
 (* ----------------------------------------------------- *)
@@ -97,18 +115,22 @@ and default_person
       Field Type: Vct_non_nullary_constructor: Ft_basic_type: Bt_string
 
       Encoding Number: 6, Payload Kind: Pk_bytes
-      Options: {"validate.rules.string.prefix": Constant_string "foo"}
+      Options: [{
+   "(validate.rules).string.prefix": "foo"
+   }]
     Constructor: Y
       Field Type: Vct_non_nullary_constructor: Ft_basic_type: Bt_int32
 
       Encoding Number: 7, Payload Kind: Pk_varint (zigzag: false)
-      Options: {"validate.rules.int32.gt": Constant_int 0}
+      Options: [{
+   "(validate.rules).int32.gt": 0
+   }]
     Constructor: Z
       Field Type: Vct_non_nullary_constructor: Ft_basic_type: Bt_float
 
       Encoding Number: 8, Payload Kind: Pk_bits32
-      Options: {}
-  Options: {}
+      Options: []
+  Options: []
 *)
 
 (*
@@ -116,21 +138,38 @@ and default_person
   Record: person
   - Field: id
     Rft_nolabel (Field Type: Ft_basic_type: Bt_int64, Encoding: 1, Payload Kind: Pk_varint (zigzag: false))
-    Field options: {"validate.rules.uint64.gt": Constant_int 999}
+    Field options: [{
+   "(validate.rules).uint64.gt": 999
+   }]
   - Field: email
     Rft_nolabel (Field Type: Ft_basic_type: Bt_string, Encoding: 2, Payload Kind: Pk_bytes)
-    Field options: {"validate.rules.string.email": Constant_bool true}
+    Field options: [{
+   "(validate.rules).string.email": true
+   }]
   - Field: name
     Rft_nolabel (Field Type: Ft_basic_type: Bt_string, Encoding: 3, Payload Kind: Pk_bytes)
-    Field options: {"validate.rules.string": {"pattern": Constant_string "^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$", "max_bytes": Constant_int 256}}
+    Field options: [{
+   "(validate.rules).string": {"pattern": "^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$",
+                               "max_bytes": 256}
+   }]
   - Field: home
     Rft_optional (Field Type: Ft_user_defined_type: person_location, Encoding: 4, Payload Kind: Pk_bytes, Default Value: None)
-    Field options: {"validate.rules.message.required": Constant_bool true}
+    Field options: [{
+   "(validate.rules).message.required": true
+   }]
   - Field: picture
     Rft_nolabel (Field Type: Ft_basic_type: Bt_bytes, Encoding: 5, Payload Kind: Pk_bytes)
-    Field options: {"validate.rules.bytes": {"not_in": [Constant_string "foo", Constant_string "bar", Constant_string "baz"]}}
+    Field options: [{
+   "(validate.rules).bytes": {"not_in": ["foo",
+                                         "bar",
+                                         "baz"]}
+   }]
   - Field: id
     Rft_variant: person_id
-    Field options: {"validate.required": Constant_bool true}
-  Options: {"validate.disabled": Constant_bool true}
+    Field options: [{
+   "(validate.required)": true
+   }]
+  Options: [{
+   "(validate.disabled)": true
+   }]
 *)

--- a/src/tests/expectation/option_processing.ml.expected
+++ b/src/tests/expectation/option_processing.ml.expected
@@ -93,14 +93,14 @@ and default_person
   - Field: lat
     Rft_nolabel (Field Type: Ft_basic_type: Bt_float, Encoding: 1, Payload Kind: Pk_bits64)
     Field options: [{
-   "(validate.rules).double": {"gte": -90,
-                               "lte": 90}
+   "(validate.rules)": {"double": {"gte": -90,
+                                   "lte": 90}}
    }]
   - Field: lng
     Rft_nolabel (Field Type: Ft_basic_type: Bt_float, Encoding: 2, Payload Kind: Pk_bits64)
     Field options: [{
-   "(validate.rules).double": {"gte": -180,
-                               "lte": 180}
+   "(validate.rules)": {"double": {"gte": -180,
+                                   "lte": 180}}
    }]
   Options: [{
    "(validate.disabled)": true
@@ -116,14 +116,14 @@ and default_person
 
       Encoding Number: 6, Payload Kind: Pk_bytes
       Options: [{
-   "(validate.rules).string.prefix": "foo"
+   "(validate.rules)": {"string": {"prefix": "foo"}}
    }]
     Constructor: Y
       Field Type: Vct_non_nullary_constructor: Ft_basic_type: Bt_int32
 
       Encoding Number: 7, Payload Kind: Pk_varint (zigzag: false)
       Options: [{
-   "(validate.rules).int32.gt": 0
+   "(validate.rules)": {"int32": {"gt": 0}}
    }]
     Constructor: Z
       Field Type: Vct_non_nullary_constructor: Ft_basic_type: Bt_float
@@ -139,30 +139,30 @@ and default_person
   - Field: id
     Rft_nolabel (Field Type: Ft_basic_type: Bt_int64, Encoding: 1, Payload Kind: Pk_varint (zigzag: false))
     Field options: [{
-   "(validate.rules).uint64.gt": 999
+   "(validate.rules)": {"uint64": {"gt": 999}}
    }]
   - Field: email
     Rft_nolabel (Field Type: Ft_basic_type: Bt_string, Encoding: 2, Payload Kind: Pk_bytes)
     Field options: [{
-   "(validate.rules).string.email": true
+   "(validate.rules)": {"string": {"email": true}}
    }]
   - Field: name
     Rft_nolabel (Field Type: Ft_basic_type: Bt_string, Encoding: 3, Payload Kind: Pk_bytes)
     Field options: [{
-   "(validate.rules).string": {"pattern": "^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$",
-                               "max_bytes": 256}
+   "(validate.rules)": {"string": {"pattern": "^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$",
+                                   "max_bytes": 256}}
    }]
   - Field: home
     Rft_optional (Field Type: Ft_user_defined_type: person_location, Encoding: 4, Payload Kind: Pk_bytes, Default Value: None)
     Field options: [{
-   "(validate.rules).message.required": true
+   "(validate.rules)": {"message": {"required": true}}
    }]
   - Field: picture
     Rft_nolabel (Field Type: Ft_basic_type: Bt_bytes, Encoding: 5, Payload Kind: Pk_bytes)
     Field options: [{
-   "(validate.rules).bytes": {"not_in": ["foo",
-                                         "bar",
-                                         "baz"]}
+   "(validate.rules)": {"bytes": {"not_in": ["foo",
+                                             "bar",
+                                             "baz"]}}
    }]
   - Field: id
     Rft_variant: person_id

--- a/src/tests/expectation/option_processing.proto
+++ b/src/tests/expectation/option_processing.proto
@@ -40,3 +40,15 @@ message Person {
     float  z = 8;
   }
 }
+
+message DestructuredOptions {
+  option (google.api.http).custom.kind = "FETCH";
+  option (google.api.http).custom.path = "/foo/bar/baz/{id}";
+  option (google.api.http).additional_bindings = {
+      get: "/foo/bar/baz/{id}"
+  };
+  option (google.api.http).additional_bindings = {
+      post: "/foo/bar/baz/",
+      body: "*"
+  };
+}

--- a/src/tests/expectation/tests.expected
+++ b/src/tests/expectation/tests.expected
@@ -273,7 +273,7 @@
                   id = 7;
                   message_name = "OptionMessage";
                   message_body = [{
-                                    "my_option": true
+                                    "(my_option)": true
                                     };
                                   {
                                      field_name = "id";
@@ -281,7 +281,7 @@
                                      field_label = `Nolabel;
                                      field_type = Int32;
                                      field_options = [{
-                                                        "my_field_option": "value"
+                                                        "(my_field_option)": "value"
                                                         }];
                                      };
                                   {
@@ -713,7 +713,7 @@
                                      field_label = `Nolabel;
                                      field_type = Uint64;
                                      field_options = [{
-                                                        "validate.rules.uint64.gt": 999
+                                                        "(validate.rules).uint64.gt": 999
                                                         }];
                                      };
                                   {
@@ -722,7 +722,7 @@
                                      field_label = `Nolabel;
                                      field_type = String;
                                      field_options = [{
-                                                        "validate.rules.string.email": true
+                                                        "(validate.rules).string.email": true
                                                         }];
                                      };
                                   {
@@ -731,7 +731,7 @@
                                      field_label = `Nolabel;
                                      field_type = String;
                                      field_options = [{
-                                                        "validate.rules.string": {
+                                                        "(validate.rules).string": {
                                                       "pattern": "^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$",
                                                       "max_bytes": 256}
                                                         }];
@@ -746,7 +746,7 @@
                                                      from_root: false
                                                      };
                                      field_options = [{
-                                                        "validate.rules.message.required": true
+                                                        "(validate.rules).message.required": true
                                                         }];
                                      };
                                   {
@@ -759,7 +759,7 @@
                                                         field_type = Double;
                                                         field_options = [
                                                         {
-                                                          "validate.rules.double": {
+                                                          "(validate.rules).double": {
                                                         "gte": -90,
                                                         "lte": 90}
                                                           }];
@@ -771,7 +771,7 @@
                                                         field_type = Double;
                                                         field_options = [
                                                         {
-                                                          "validate.rules.double": {
+                                                          "(validate.rules).double": {
                                                         "gte": -180,
                                                         "lte": 180}
                                                           }];
@@ -783,7 +783,7 @@
                   message_name = "Other";
                   message_body = [{oneof_name = "id";
                                      oneof_body = [{
-                                                     "validate.required": true
+                                                     "(validate.required)": true
                                                      };
                                                    {
                                                       field_name = "x";
@@ -792,7 +792,7 @@
                                                       field_type = String;
                                                       field_options = [
                                                       {
-                                                        "validate.rules.string.len": 5
+                                                        "(validate.rules).string.len": 5
                                                         }];
                                                       };
                                                    {
@@ -822,7 +822,7 @@
                                      field_label = `Nolabel;
                                      field_type = Uint32;
                                      field_options = [{
-                                                        "validate.rules.uint32": {
+                                                        "(validate.rules).uint32": {
                                                       "in": [1,
                                                              2,
                                                              3]}
@@ -834,7 +834,7 @@
                                      field_label = `Nolabel;
                                      field_type = Float;
                                      field_options = [{
-                                                        "validate.rules.float": {
+                                                        "(validate.rules).float": {
                                                       "not_in": [0,
                                                                  0.990000]}
                                                         }];
@@ -927,7 +927,7 @@
                {
                   service_name = "ShelfServiceV2";
                   service_body = [{
-                                    "some.config": "service_shelf"
+                                    "(some.config)": "service_shelf"
                                     };
                                   {
                                      rpc_name = "ListShelves";
@@ -996,10 +996,10 @@
                                   {
                                      rpc_name = "GetShelf";
                                      rpc_options = [{
-                                                      "const.config": "rpc_shelf"
+                                                      "(const.config)": "rpc_shelf"
                                                       },
                                                     {
-                                                      "google.api.http": {
+                                                      "(google.api.http)": {
                                                     "post": "/v1/shelves/{shelf}",
                                                     "body": "body"}
                                                       }];

--- a/src/tests/expectation/tests.expected
+++ b/src/tests/expectation/tests.expected
@@ -713,8 +713,7 @@
                                      field_label = `Nolabel;
                                      field_type = Uint64;
                                      field_options = [{
-                                                        "(validate.rules)": {
-                                                      "uint64": {"gt": 999}}
+                                                        "(validate.rules).uint64.gt": 999
                                                         }];
                                      };
                                   {
@@ -723,8 +722,7 @@
                                      field_label = `Nolabel;
                                      field_type = String;
                                      field_options = [{
-                                                        "(validate.rules)": {
-                                                      "string": {"email": true}}
+                                                        "(validate.rules).string.email": true
                                                         }];
                                      };
                                   {
@@ -733,9 +731,9 @@
                                      field_label = `Nolabel;
                                      field_type = String;
                                      field_options = [{
-                                                        "(validate.rules)": {
-                                                      "string": {"pattern": "^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$",
-                                                                 "max_bytes": 256}}
+                                                        "(validate.rules).string": {
+                                                      "pattern": "^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$",
+                                                      "max_bytes": 256}
                                                         }];
                                      };
                                   {
@@ -748,8 +746,7 @@
                                                      from_root: false
                                                      };
                                      field_options = [{
-                                                        "(validate.rules)": {
-                                                      "message": {"required": true}}
+                                                        "(validate.rules).message.required": true
                                                         }];
                                      };
                                   {
@@ -762,9 +759,9 @@
                                                         field_type = Double;
                                                         field_options = [
                                                         {
-                                                          "(validate.rules)": {
-                                                        "double": {"gte": -90,
-                                                                   "lte": 90}}
+                                                          "(validate.rules).double": {
+                                                        "gte": -90,
+                                                        "lte": 90}
                                                           }];
                                                         };
                                                      {
@@ -774,9 +771,9 @@
                                                         field_type = Double;
                                                         field_options = [
                                                         {
-                                                          "(validate.rules)": {
-                                                        "double": {"gte": -180,
-                                                                   "lte": 180}}
+                                                          "(validate.rules).double": {
+                                                        "gte": -180,
+                                                        "lte": 180}
                                                           }];
                                                         }];
                                      }];
@@ -795,8 +792,7 @@
                                                       field_type = String;
                                                       field_options = [
                                                       {
-                                                        "(validate.rules)": {
-                                                      "string": {"len": 5}}
+                                                        "(validate.rules).string.len": 5
                                                         }];
                                                       };
                                                    {
@@ -826,11 +822,10 @@
                                      field_label = `Nolabel;
                                      field_type = Uint32;
                                      field_options = [{
-                                                        "(validate.rules)": {
-                                                      "uint32": {"in": [
-                                                                 1,
-                                                                 2,
-                                                                 3]}}
+                                                        "(validate.rules).uint32": {
+                                                      "in": [1,
+                                                             2,
+                                                             3]}
                                                         }];
                                      };
                                   {
@@ -839,10 +834,9 @@
                                      field_label = `Nolabel;
                                      field_type = Float;
                                      field_options = [{
-                                                        "(validate.rules)": {
-                                                      "float": {"not_in": [
-                                                                0,
-                                                                0.990000]}}
+                                                        "(validate.rules).float": {
+                                                      "not_in": [0,
+                                                                 0.990000]}
                                                         }];
                                      }];
                   }];

--- a/src/tests/expectation/tests.expected
+++ b/src/tests/expectation/tests.expected
@@ -713,7 +713,8 @@
                                      field_label = `Nolabel;
                                      field_type = Uint64;
                                      field_options = [{
-                                                        "(validate.rules).uint64.gt": 999
+                                                        "(validate.rules)": {
+                                                      "uint64": {"gt": 999}}
                                                         }];
                                      };
                                   {
@@ -722,7 +723,8 @@
                                      field_label = `Nolabel;
                                      field_type = String;
                                      field_options = [{
-                                                        "(validate.rules).string.email": true
+                                                        "(validate.rules)": {
+                                                      "string": {"email": true}}
                                                         }];
                                      };
                                   {
@@ -731,9 +733,9 @@
                                      field_label = `Nolabel;
                                      field_type = String;
                                      field_options = [{
-                                                        "(validate.rules).string": {
-                                                      "pattern": "^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$",
-                                                      "max_bytes": 256}
+                                                        "(validate.rules)": {
+                                                      "string": {"pattern": "^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$",
+                                                                 "max_bytes": 256}}
                                                         }];
                                      };
                                   {
@@ -746,7 +748,8 @@
                                                      from_root: false
                                                      };
                                      field_options = [{
-                                                        "(validate.rules).message.required": true
+                                                        "(validate.rules)": {
+                                                      "message": {"required": true}}
                                                         }];
                                      };
                                   {
@@ -759,9 +762,9 @@
                                                         field_type = Double;
                                                         field_options = [
                                                         {
-                                                          "(validate.rules).double": {
-                                                        "gte": -90,
-                                                        "lte": 90}
+                                                          "(validate.rules)": {
+                                                        "double": {"gte": -90,
+                                                                   "lte": 90}}
                                                           }];
                                                         };
                                                      {
@@ -771,9 +774,9 @@
                                                         field_type = Double;
                                                         field_options = [
                                                         {
-                                                          "(validate.rules).double": {
-                                                        "gte": -180,
-                                                        "lte": 180}
+                                                          "(validate.rules)": {
+                                                        "double": {"gte": -180,
+                                                                   "lte": 180}}
                                                           }];
                                                         }];
                                      }];
@@ -792,7 +795,8 @@
                                                       field_type = String;
                                                       field_options = [
                                                       {
-                                                        "(validate.rules).string.len": 5
+                                                        "(validate.rules)": {
+                                                      "string": {"len": 5}}
                                                         }];
                                                       };
                                                    {
@@ -822,10 +826,11 @@
                                      field_label = `Nolabel;
                                      field_type = Uint32;
                                      field_options = [{
-                                                        "(validate.rules).uint32": {
-                                                      "in": [1,
-                                                             2,
-                                                             3]}
+                                                        "(validate.rules)": {
+                                                      "uint32": {"in": [
+                                                                 1,
+                                                                 2,
+                                                                 3]}}
                                                         }];
                                      };
                                   {
@@ -834,9 +839,10 @@
                                      field_label = `Nolabel;
                                      field_type = Float;
                                      field_options = [{
-                                                        "(validate.rules).float": {
-                                                      "not_in": [0,
-                                                                 0.990000]}
+                                                        "(validate.rules)": {
+                                                      "float": {"not_in": [
+                                                                0,
+                                                                0.990000]}}
                                                         }];
                                      }];
                   }];

--- a/src/tests/unit-tests/parse_field_options.ml
+++ b/src/tests/unit-tests/parse_field_options.ml
@@ -1,7 +1,7 @@
 let parse f s = f Pb_parsing_lexer.lexer (Lexing.from_string s)
 
 let has_option set option_name =
-  match Pb_option.get set (Pb_option.Simple_name option_name) with
+  match Pb_raw_option.get_simple set option_name with
   | None -> false
   | Some _ -> true
 
@@ -9,9 +9,9 @@ module Pt = Pb_parsing_parse_tree
 
 let () =
   let test_default s =
-    Pb_option.get
+    Pb_raw_option.get_simple
       (parse Pb_parsing_parser.field_options_ s)
-      (Pb_option.Simple_name "default")
+      "default"
     |> function
     | Some (Pb_option.Scalar_value x) -> x
     | _ -> assert false
@@ -34,7 +34,7 @@ let () =
 
 let () =
   let field_options = parse Pb_parsing_parser.field_options_ "[]" in
-  assert (field_options = Pb_option.empty)
+  assert (field_options = Pb_raw_option.empty)
 
 let () =
   let field_options = parse Pb_parsing_parser.field_options_ "[a=1,b=true]" in
@@ -48,6 +48,6 @@ let () =
   in
   assert (
     Some Pb_option.(Scalar_value (Constant_literal "int"))
-    = Pb_option.get_ext field_options "ocaml_type")
+    = Pb_raw_option.get_ext field_options "ocaml_type")
 
 let () = print_endline "Parse Field Options ... Ok"

--- a/src/tests/unit-tests/parse_field_options.ml
+++ b/src/tests/unit-tests/parse_field_options.ml
@@ -1,7 +1,7 @@
 let parse f s = f Pb_parsing_lexer.lexer (Lexing.from_string s)
 
 let has_option set option_name =
-  match Pb_option.get set [ Pb_option.Simple_name option_name ] with
+  match Pb_option.get set (Pb_option.Simple_name option_name) with
   | None -> false
   | Some _ -> true
 
@@ -11,7 +11,7 @@ let () =
   let test_default s =
     Pb_option.get
       (parse Pb_parsing_parser.field_options_ s)
-      [ Pb_option.Simple_name "default" ]
+      (Pb_option.Simple_name "default")
     |> function
     | Some (Pb_option.Scalar_value x) -> x
     | _ -> assert false

--- a/src/tests/unit-tests/parse_field_options.ml
+++ b/src/tests/unit-tests/parse_field_options.ml
@@ -1,7 +1,7 @@
 let parse f s = f Pb_parsing_lexer.lexer (Lexing.from_string s)
 
 let has_option set option_name =
-  match Pb_option.get set option_name with
+  match Pb_option.get set [ Pb_option.Simple_name option_name ] with
   | None -> false
   | Some _ -> true
 
@@ -9,7 +9,9 @@ module Pt = Pb_parsing_parse_tree
 
 let () =
   let test_default s =
-    Pb_option.get (parse Pb_parsing_parser.field_options_ s) "default"
+    Pb_option.get
+      (parse Pb_parsing_parser.field_options_ s)
+      [ Pb_option.Simple_name "default" ]
     |> function
     | Some (Pb_option.Scalar_value x) -> x
     | _ -> assert false
@@ -46,6 +48,6 @@ let () =
   in
   assert (
     Some Pb_option.(Scalar_value (Constant_literal "int"))
-    = Pb_option.get field_options "ocaml_type")
+    = Pb_option.get_ext field_options "ocaml_type")
 
 let () = print_endline "Parse Field Options ... Ok"

--- a/src/tests/unit-tests/parse_file_options.ml
+++ b/src/tests/unit-tests/parse_file_options.ml
@@ -9,7 +9,7 @@ module Pt = Pb_parsing_parse_tree
 let () =
   let s = "option blah = 1;" in
   let fo =
-    [ Pb_option.Simple_name "blah" ], Pb_option.(Scalar_value (Constant_int 1))
+    Pb_option.Simple_name "blah", Pb_option.(Scalar_value (Constant_int 1))
   in
   assert (fo = parse s)
 
@@ -19,10 +19,10 @@ let () =
   let fo_parsed = proto.Pt.file_options in
   assert (
     Some Pb_option.(Scalar_value (Constant_int 1))
-    = Pb_option.get fo_parsed [ Pb_option.Simple_name "blah" ]);
+    = Pb_option.get fo_parsed (Pb_option.Simple_name "blah"));
   assert (
     Some Pb_option.(Scalar_value (Constant_string "blah"))
-    = Pb_option.get fo_parsed [ Pb_option.Simple_name "foo" ]);
+    = Pb_option.get fo_parsed (Pb_option.Simple_name "foo"));
   ()
 
 let () = print_endline "Parse File Options ... Ok"

--- a/src/tests/unit-tests/parse_file_options.ml
+++ b/src/tests/unit-tests/parse_file_options.ml
@@ -8,7 +8,9 @@ module Pt = Pb_parsing_parse_tree
 
 let () =
   let s = "option blah = 1;" in
-  let fo = "blah", Pb_option.(Scalar_value (Constant_int 1)) in
+  let fo =
+    [ Pb_option.Simple_name "blah" ], Pb_option.(Scalar_value (Constant_int 1))
+  in
   assert (fo = parse s)
 
 let () =
@@ -17,10 +19,10 @@ let () =
   let fo_parsed = proto.Pt.file_options in
   assert (
     Some Pb_option.(Scalar_value (Constant_int 1))
-    = Pb_option.get fo_parsed "blah");
+    = Pb_option.get fo_parsed [ Pb_option.Simple_name "blah" ]);
   assert (
     Some Pb_option.(Scalar_value (Constant_string "blah"))
-    = Pb_option.get fo_parsed "foo");
+    = Pb_option.get fo_parsed [ Pb_option.Simple_name "foo" ]);
   ()
 
 let () = print_endline "Parse File Options ... Ok"

--- a/src/tests/unit-tests/parse_file_options.ml
+++ b/src/tests/unit-tests/parse_file_options.ml
@@ -9,7 +9,8 @@ module Pt = Pb_parsing_parse_tree
 let () =
   let s = "option blah = 1;" in
   let fo =
-    Pb_option.Simple_name "blah", Pb_option.(Scalar_value (Constant_int 1))
+    ( [ Pb_raw_option.Simple_name "blah" ],
+      Pb_option.(Scalar_value (Constant_int 1)) )
   in
   assert (fo = parse s)
 
@@ -19,10 +20,10 @@ let () =
   let fo_parsed = proto.Pt.file_options in
   assert (
     Some Pb_option.(Scalar_value (Constant_int 1))
-    = Pb_option.get fo_parsed (Pb_option.Simple_name "blah"));
+    = Pb_raw_option.get_simple fo_parsed "blah");
   assert (
     Some Pb_option.(Scalar_value (Constant_string "blah"))
-    = Pb_option.get fo_parsed (Pb_option.Simple_name "foo"));
+    = Pb_raw_option.get_simple fo_parsed "foo");
   ()
 
 let () = print_endline "Parse File Options ... Ok"


### PR DESCRIPTION
This PR introduces `Pb_raw_option`, which is a raw set of options as they are parsed from the .proto file. `Pb_option` is modified to actually be a compiled set of options. See https://protobuf.com/docs/language-spec#options for more details on how options are represented and thus should be parsed. Citing the example from that link here (same example is also added to tests to illustrate the new option parsing behavior and its correctness):

The example below demonstrates use of destructured messages and destructured lists:

```proto
option (google.api.http).custom.kind = "FETCH";
option (google.api.http).custom.path = "/foo/bar/baz/{id}";
option (google.api.http).additional_bindings = {
    get: "/foo/bar/baz/{id}"
};
option (google.api.http).additional_bindings = {
    post: "/foo/bar/baz/"
    body: "*"
};
```

The following is equivalent to the above, and instead uses a single message literal instead of de-structuring:

```
option (google.api.http) = {
    custom: {
        kind: "FETCH"
        path: "/foo/bar/baz/{id}"
    }
    additional_bindings: [
      {
          get: "/foo/bar/baz/{id}"
      },
      {
          post: "/foo/bar/baz/"
          body: "*"
      }
    ]
};
```
