### PR TITLE
decoder offset + yojson fixes

### DIFF
--- a/src/compilerlib/pb_codegen_decode_yojson.ml
+++ b/src/compilerlib/pb_codegen_decode_yojson.ml
@@ -3,6 +3,12 @@ module F = Pb_codegen_formatting
 
 let sp = Pb_codegen_util.sp
 
+(* Emit a field name pattern that matches both the camelCase json_name and the
+   original proto field name (snake_case), as required by the ProtoJSON spec. *)
+let field_name_pattern json_label proto_label =
+  if json_label = proto_label then sp "\"%s\"" json_label
+  else sp "(\"%s\" | \"%s\")" json_label proto_label
+
 (** Function which returns all the possible pattern match for reading a JSON
     value into an OCaml value. The protobuf JSON encoding rules are defined
     here: https://developers.google.com/protocol-buffers/docs/proto3#json *)
@@ -41,11 +47,12 @@ let field_pattern_match ~r_name ~rf_label field_type =
 (* Generate all the pattern matches for a record field *)
 let gen_rft_nolabel sc ~r_name ~rf_label (field_type, _, _) =
   let json_label = Pb_codegen_util.camel_case_of_label rf_label in
+  let name_pat = field_name_pattern json_label rf_label in
 
   let match_variable_name, exp =
     field_pattern_match ~r_name ~rf_label field_type
   in
-  F.linep sc "| (\"%s\", %s) -> " json_label match_variable_name;
+  F.linep sc "| (%s, %s) -> " name_pat match_variable_name;
   F.linep sc "  %s_set_%s v (%s)" r_name rf_label exp
 
 (* Generate all the pattern matches for a repeated field *)
@@ -53,8 +60,9 @@ let gen_rft_repeated_field sc ~r_name ~rf_label repeated_field =
   let _, field_type, _, _, _ = repeated_field in
 
   let json_label = Pb_codegen_util.camel_case_of_label rf_label in
+  let name_pat = field_name_pattern json_label rf_label in
 
-  F.linep sc "| (\"%s\", `List l) -> begin" json_label;
+  F.linep sc "| (%s, `List l) -> begin" name_pat;
 
   F.sub_scope sc (fun sc ->
       F.linep sc "%s_set_%s v @@ List.map (function" r_name rf_label;
@@ -70,12 +78,13 @@ let gen_rft_optional_field sc ~r_name ~rf_label optional_field =
   let field_type, _, _, _ = optional_field in
 
   let json_label = Pb_codegen_util.camel_case_of_label rf_label in
+  let name_pat = field_name_pattern json_label rf_label in
 
   let match_variable_name, exp =
     field_pattern_match ~r_name ~rf_label field_type
   in
 
-  F.linep sc "| (\"%s\", %s) -> " json_label match_variable_name;
+  F.linep sc "| (%s, %s) -> " name_pat match_variable_name;
   F.linep sc "  %s_set_%s v %s" r_name rf_label exp
 
 (* Generate pattern match for a variant field *)
@@ -85,22 +94,25 @@ let gen_rft_variant_field sc ~r_name ~rf_label { Ot.v_constructors; _ } =
       let json_label =
         Pb_codegen_util.camel_case_of_constructor vc_constructor
       in
+      let proto_label = String.lowercase_ascii vc_constructor in
+      let name_pat = field_name_pattern json_label proto_label in
 
       match vc_field_type with
       | Ot.Vct_nullary ->
-        F.linep sc "| (\"%s\", _) -> %s_set_%s v %s" json_label r_name rf_label
+        F.linep sc "| (%s, _) -> %s_set_%s v %s" name_pat r_name rf_label
           vc_constructor
       | Ot.Vct_non_nullary_constructor field_type ->
         let match_variable_name, exp =
           field_pattern_match ~r_name ~rf_label field_type
         in
-        F.linep sc "| (\"%s\", %s) -> " json_label match_variable_name;
+        F.linep sc "| (%s, %s) -> " name_pat match_variable_name;
         F.linep sc "  %s_set_%s v (%s (%s))" r_name rf_label vc_constructor exp)
     v_constructors
 
 let gen_rft_assoc_field sc ~r_name ~rf_label ~assoc_type ~key_type ~value_type =
   let json_label = Pb_codegen_util.camel_case_of_label rf_label in
-  F.linep sc "| (\"%s\", `Assoc assoc) ->" json_label;
+  let name_pat = field_name_pattern json_label rf_label in
+  F.linep sc "| (%s, `Assoc assoc) ->" name_pat;
   F.sub_scope sc (fun sc ->
       let value_name, value_exp =
         field_pattern_match ~r_name ~rf_label value_type
@@ -148,8 +160,7 @@ let gen_record ?and_ { Ot.r_name; r_fields } sc =
       F.linep sc "let v = default_%s () in" r_name;
       F.line sc @@ "let assoc = match d with";
       F.line sc @@ "  | `Assoc assoc -> assoc";
-      F.line sc @@ "  | _ -> assert(false)";
-      (* TODO raise E *)
+      F.linep sc "  | _ -> Pbrt_yojson.E.unexpected_json_type \"%s\" __MODULE__" r_name;
       F.line sc @@ "in";
 
       F.line sc "List.iter (function ";
@@ -207,17 +218,19 @@ let gen_variant ?and_ { Ot.v_name; v_constructors; v_use_polyvariant = _ } sc =
   (* helper function for each constructor case *)
   let process_v_constructor sc { Ot.vc_constructor; vc_field_type; _ } =
     let json_label = Pb_codegen_util.camel_case_of_constructor vc_constructor in
+    let proto_label = String.lowercase_ascii vc_constructor in
+    let name_pat = field_name_pattern json_label proto_label in
 
     match vc_field_type with
     | Ot.Vct_nullary ->
-      F.linep sc "| (\"%s\", _)::_-> (%s : %s)" json_label vc_constructor v_name
+      F.linep sc "| (%s, _)::_-> (%s : %s)" name_pat vc_constructor v_name
     | Ot.Vct_non_nullary_constructor field_type ->
       let match_, exp =
         let r_name = v_name and rf_label = vc_constructor in
         field_pattern_match ~r_name ~rf_label field_type
       in
 
-      F.linep sc "| (\"%s\", %s)::_ -> " json_label match_;
+      F.linep sc "| (%s, %s)::_ -> " name_pat match_;
       F.linep sc "  (%s (%s) : %s)" vc_constructor exp v_name
   in
 
@@ -232,8 +245,7 @@ let gen_variant ?and_ { Ot.v_name; v_constructors; v_use_polyvariant = _ } sc =
        * of the cases it will be a single iteration *)
       F.line sc "let assoc = match json with";
       F.line sc "  | `Assoc assoc -> assoc";
-      F.line sc "  | _ -> assert(false)";
-      (* TODO raise E *)
+      F.linep sc "  | _ -> Pbrt_yojson.E.unexpected_json_type \"%s\" __MODULE__" v_name;
       F.line sc "in";
 
       F.line sc "let rec loop = function";

--- a/src/compilerlib/pb_codegen_decode_yojson.ml
+++ b/src/compilerlib/pb_codegen_decode_yojson.ml
@@ -6,8 +6,10 @@ let sp = Pb_codegen_util.sp
 (* Emit a field name pattern that matches both the camelCase json_name and the
    original proto field name (snake_case), as required by the ProtoJSON spec. *)
 let field_name_pattern json_label proto_label =
-  if json_label = proto_label then sp "\"%s\"" json_label
-  else sp "(\"%s\" | \"%s\")" json_label proto_label
+  if json_label = proto_label then
+    sp "\"%s\"" json_label
+  else
+    sp "(\"%s\" | \"%s\")" json_label proto_label
 
 (** Function which returns all the possible pattern match for reading a JSON
     value into an OCaml value. The protobuf JSON encoding rules are defined
@@ -160,7 +162,8 @@ let gen_record ?and_ { Ot.r_name; r_fields } sc =
       F.linep sc "let v = default_%s () in" r_name;
       F.line sc @@ "let assoc = match d with";
       F.line sc @@ "  | `Assoc assoc -> assoc";
-      F.linep sc "  | _ -> Pbrt_yojson.E.unexpected_json_type \"%s\" __MODULE__" r_name;
+      F.linep sc "  | _ -> Pbrt_yojson.E.unexpected_json_type \"%s\" __MODULE__"
+        r_name;
       F.line sc @@ "in";
 
       F.line sc "List.iter (function ";
@@ -245,7 +248,8 @@ let gen_variant ?and_ { Ot.v_name; v_constructors; v_use_polyvariant = _ } sc =
        * of the cases it will be a single iteration *)
       F.line sc "let assoc = match json with";
       F.line sc "  | `Assoc assoc -> assoc";
-      F.linep sc "  | _ -> Pbrt_yojson.E.unexpected_json_type \"%s\" __MODULE__" v_name;
+      F.linep sc "  | _ -> Pbrt_yojson.E.unexpected_json_type \"%s\" __MODULE__"
+        v_name;
       F.line sc "in";
 
       F.line sc "let rec loop = function";

--- a/src/compilerlib/pb_codegen_encode_yojson.ml
+++ b/src/compilerlib/pb_codegen_encode_yojson.ml
@@ -11,8 +11,8 @@ let runtime_function_for_basic_type json_label basic_type pk =
   (* String *)
   | Ot.Bt_string, _ -> "make_string", None
   (* Float *)
-  | Ot.Bt_float, Ot.Pk_bits32 -> "make_float", None
-  | Ot.Bt_float, Ot.Pk_bits64 -> "make_string", Some "string_of_float"
+  | Ot.Bt_float, Ot.Pk_bits32 -> "encode_float", None
+  | Ot.Bt_float, Ot.Pk_bits64 -> "encode_float", None
   (* Int32 *)
   | Ot.Bt_int32, Ot.Pk_varint _ | Ot.Bt_int32, Ot.Pk_bits32 ->
     "make_int", Some "Int32.to_int"

--- a/src/examples/build_server.ml.expected
+++ b/src/examples/build_server.ml.expected
@@ -113,7 +113,7 @@ let rec decode_json_file_path d =
   let v = default_file_path () in
   let assoc = match d with
     | `Assoc assoc -> assoc
-    | _ -> assert(false)
+    | _ -> Pbrt_yojson.E.unexpected_json_type "file_path" __MODULE__
   in
   List.iter (function 
     | ("path", json_value) -> 

--- a/src/examples/calculator.ml.expected
+++ b/src/examples/calculator.ml.expected
@@ -288,7 +288,7 @@ let rec decode_json_i32 d =
   let v = default_i32 () in
   let assoc = match d with
     | `Assoc assoc -> assoc
-    | _ -> assert(false)
+    | _ -> Pbrt_yojson.E.unexpected_json_type "i32" __MODULE__
   in
   List.iter (function 
     | ("value", json_value) -> 
@@ -305,7 +305,7 @@ let rec decode_json_add_req d =
   let v = default_add_req () in
   let assoc = match d with
     | `Assoc assoc -> assoc
-    | _ -> assert(false)
+    | _ -> Pbrt_yojson.E.unexpected_json_type "add_req" __MODULE__
   in
   List.iter (function 
     | ("a", json_value) -> 
@@ -325,7 +325,7 @@ let rec decode_json_add_all_req d =
   let v = default_add_all_req () in
   let assoc = match d with
     | `Assoc assoc -> assoc
-    | _ -> assert(false)
+    | _ -> Pbrt_yojson.E.unexpected_json_type "add_all_req" __MODULE__
   in
   List.iter (function 
     | ("ints", `List l) -> begin

--- a/src/examples/file_server.ml.expected
+++ b/src/examples/file_server.ml.expected
@@ -329,7 +329,7 @@ let rec decode_json_file_chunk d =
   let v = default_file_chunk () in
   let assoc = match d with
     | `Assoc assoc -> assoc
-    | _ -> assert(false)
+    | _ -> Pbrt_yojson.E.unexpected_json_type "file_chunk" __MODULE__
   in
   List.iter (function 
     | ("path", json_value) -> 
@@ -352,7 +352,7 @@ let rec decode_json_file_path d =
   let v = default_file_path () in
   let assoc = match d with
     | `Assoc assoc -> assoc
-    | _ -> assert(false)
+    | _ -> Pbrt_yojson.E.unexpected_json_type "file_path" __MODULE__
   in
   List.iter (function 
     | ("path", json_value) -> 
@@ -369,7 +369,7 @@ let rec decode_json_file_crc d =
   let v = default_file_crc () in
   let assoc = match d with
     | `Assoc assoc -> assoc
-    | _ -> assert(false)
+    | _ -> Pbrt_yojson.E.unexpected_json_type "file_crc" __MODULE__
   in
   List.iter (function 
     | ("crc", json_value) -> 

--- a/src/runtime-yojson/pbrt_yojson.ml
+++ b/src/runtime-yojson/pbrt_yojson.ml
@@ -82,6 +82,12 @@ let make_int v = `Int v
 let make_float v = `Float v
 let make_string v = `String v
 
+let encode_float v =
+  if Float.is_nan v then `String "NaN"
+  else if Float.is_infinite v && v > 0. then `String "Infinity"
+  else if Float.is_infinite v then `String "-Infinity"
+  else `Float v
+
 let make_bytes s =
   make_string (s |> Bytes.to_string |> Base64.encode_exn ~pad:true)
 

--- a/src/runtime-yojson/pbrt_yojson.ml
+++ b/src/runtime-yojson/pbrt_yojson.ml
@@ -83,10 +83,14 @@ let make_float v = `Float v
 let make_string v = `String v
 
 let encode_float v =
-  if Float.is_nan v then `String "NaN"
-  else if Float.is_infinite v && v > 0. then `String "Infinity"
-  else if Float.is_infinite v then `String "-Infinity"
-  else `Float v
+  if Float.is_nan v then
+    `String "NaN"
+  else if Float.is_infinite v && v > 0. then
+    `String "Infinity"
+  else if Float.is_infinite v then
+    `String "-Infinity"
+  else
+    `Float v
 
 let make_bytes s =
   make_string (s |> Bytes.to_string |> Base64.encode_exn ~pad:true)

--- a/src/runtime-yojson/pbrt_yojson.mli
+++ b/src/runtime-yojson/pbrt_yojson.mli
@@ -33,6 +33,11 @@ val make_bool : bool -> Yojson.Basic.t
 val make_int : int -> Yojson.Basic.t
 val make_float : float -> Yojson.Basic.t
 val make_string : string -> Yojson.Basic.t
+val encode_float : float -> Yojson.Basic.t
+(** [encode_float v] encodes [v] as a JSON value. NaN, Infinity, and
+    -Infinity are encoded as the JSON strings ["NaN"], ["Infinity"],
+    ["-Infinity"] per the ProtoJSON spec. *)
+
 val make_bytes : bytes -> Yojson.Basic.t
 val make_unit : unit -> Yojson.Basic.t
 val make_list : Yojson.Basic.t list -> Yojson.Basic.t

--- a/src/runtime-yojson/pbrt_yojson.mli
+++ b/src/runtime-yojson/pbrt_yojson.mli
@@ -33,10 +33,11 @@ val make_bool : bool -> Yojson.Basic.t
 val make_int : int -> Yojson.Basic.t
 val make_float : float -> Yojson.Basic.t
 val make_string : string -> Yojson.Basic.t
+
 val encode_float : float -> Yojson.Basic.t
-(** [encode_float v] encodes [v] as a JSON value. NaN, Infinity, and
-    -Infinity are encoded as the JSON strings ["NaN"], ["Infinity"],
-    ["-Infinity"] per the ProtoJSON spec. *)
+(** [encode_float v] encodes [v] as a JSON value. NaN, Infinity, and -Infinity
+    are encoded as the JSON strings ["NaN"], ["Infinity"], ["-Infinity"] per the
+    ProtoJSON spec. *)
 
 val make_bytes : bytes -> Yojson.Basic.t
 val make_unit : unit -> Yojson.Basic.t

--- a/src/runtime/pbrt.ml
+++ b/src/runtime/pbrt.ml
@@ -88,14 +88,16 @@ module Decoder = struct
     source: bytes;
     limit: int;
     mutable offset: int;
+    initial_offset: int;
   }
 
-  let of_bytes source = { source; offset = 0; limit = Bytes.length source }
+  let of_bytes source =
+    { source; offset = 0; limit = Bytes.length source; initial_offset = 0 }
 
   let of_subbytes source offset len =
     if offset + len > Bytes.length source then
       invalid_arg "Pbrt.Decoder.of_subbypes";
-    { source; offset; limit = offset + len }
+    { source; offset; limit = offset + len; initial_offset = offset }
 
   let of_string source =
     (* safe: we won't modify the bytes *)
@@ -103,6 +105,8 @@ module Decoder = struct
 
   let of_substring source offset len =
     of_subbytes (Bytes.unsafe_of_string source) offset len
+
+  let offset d = d.offset - d.initial_offset
 
   let malformed_variant variant_name =
     raise (Failure (Malformed_variant variant_name))
@@ -196,7 +200,7 @@ module Decoder = struct
     (* strings are always shorter than range of int *)
     let len = int_as_varint d in
     if d.offset + len > d.limit then raise (Failure Incomplete);
-    let d' = { d with limit = d.offset + len } in
+    let d' = { d with limit = d.offset + len; initial_offset = d.offset } in
     d.offset <- d.offset + len;
     d'
 

--- a/src/runtime/pbrt.mli
+++ b/src/runtime/pbrt.mli
@@ -58,6 +58,13 @@ module Decoder : sig
   (** See {!of_subbytes}.
       @since 3.0 *)
 
+  val offset : t -> int
+  (** [offset d] returns the current read offset position in the underlying
+      buffer. This is useful when decoding multiple messages over a fixed-length
+      buffer: you can check how many bytes were consumed and reset the decoder
+      with the remaining data.
+      @since NEXT_RELEASE *)
+
   (** {2 Errors} *)
 
   type error =

--- a/src/tests/unit-tests/pbrt/decoder_offset.ml
+++ b/src/tests/unit-tests/pbrt/decoder_offset.ml
@@ -1,0 +1,57 @@
+module D = Pbrt.Decoder
+module E = Pbrt.Encoder
+
+(* basic of_bytes: starts at 0 *)
+let () =
+  let buf = Bytes.create 10 in
+  (* fill buf with some bytes *)
+  Bytes.fill buf 0 10 'B';
+  let d = D.of_bytes buf in
+  assert (D.offset d = 0);
+  (* skip some bytes to advance *)
+  let _ = D.int_as_varint d in
+  let pos = D.offset d in
+  assert (pos > 0);
+  ()
+
+(* of_subbytes: offset is relative to the subview start *)
+let () =
+  let buf = Bytes.create 100 in
+  Bytes.fill buf 0 100 'B';
+  (* encode a known small varint at offset 50 *)
+  let sub = Bytes.sub buf 50 10 in
+  Bytes.set sub 0 (Char.chr 5);
+  let d = D.of_subbytes buf 50 10 in
+  assert (D.offset d = 0);
+  let _ = D.int_as_varint d in
+  (* after reading one byte, offset should be 1 *)
+  assert (D.offset d = 1);
+  ()
+
+(* of_subbytes: same but with of_string and of_substring *)
+let () =
+  let s = String.make 100 '\x00' in
+  let d = D.of_substring s 50 10 in
+  assert (D.offset d = 0);
+  ()
+
+(* nested: offset is relative to the nested frame *)
+let () =
+  (* use E.nested to produce length-prefixed content, then decode it *)
+  let enc = E.create () in
+  E.nested
+    (fun () enc ->
+      E.int_as_varint 7 enc;
+      E.int_as_varint 42 enc)
+    () enc;
+  let buf = E.to_bytes enc in
+  let d = D.of_bytes buf in
+  let nested_d = D.nested d in
+  (* offset inside nested should be 0 *)
+  assert (D.offset nested_d = 0);
+  let _ = D.int_as_varint nested_d in
+  (* after reading one varint byte, offset should be 1 *)
+  assert (D.offset nested_d = 1);
+  ()
+
+let () = print_endline "offset tests passed"

--- a/src/tests/unit-tests/pbrt/dune
+++ b/src/tests/unit-tests/pbrt/dune
@@ -1,5 +1,5 @@
 (tests
  (package pbrt)
- (names pbrt_array wrapper_encoding varint)
+ (names pbrt_array wrapper_encoding varint decoder_offset)
  (libraries pbrt)
  (flags :standard))

--- a/src/tests/yojson/yojson_unittest_ml.ml
+++ b/src/tests/yojson/yojson_unittest_ml.ml
@@ -97,3 +97,54 @@ let () =
   print_endline "\nConformance tests ... Ok";
 
   ()
+
+let () =
+  let open Yojson_unittest in
+  let get_field key json =
+    match json with
+    | `Assoc fields -> List.assoc key fields
+    | _ -> failwith "expected assoc"
+  in
+  (* double (field01) special values: must encode as JSON strings "NaN", "Infinity", "-Infinity" *)
+  let check_double v expected_token =
+    let t = make_all_basic_types ~field01:v () in
+    let json = encode_json_all_basic_types t in
+    assert (get_field "field01" json = expected_token);
+    decode_json_all_basic_types json
+  in
+  let t' = check_double Float.nan (`String "NaN") in
+  assert (Float.is_nan t'.field01);
+  let t' = check_double Float.infinity (`String "Infinity") in
+  assert (t'.field01 = Float.infinity);
+  let t' = check_double Float.neg_infinity (`String "-Infinity") in
+  assert (t'.field01 = Float.neg_infinity);
+
+  (* float (field02, Pk_bits32) special values *)
+  let check_float v expected_token =
+    let t = make_all_basic_types ~field02:v () in
+    let json = encode_json_all_basic_types t in
+    assert (get_field "field02" json = expected_token);
+    decode_json_all_basic_types json
+  in
+  let t' = check_float Float.nan (`String "NaN") in
+  assert (Float.is_nan t'.field02);
+  let t' = check_float Float.infinity (`String "Infinity") in
+  assert (t'.field02 = Float.infinity);
+  let t' = check_float Float.neg_infinity (`String "-Infinity") in
+  assert (t'.field02 = Float.neg_infinity);
+
+  print_endline "\nFloat special values ... Ok"
+
+let () =
+  let open Yojson_unittest in
+  (* Decoder must accept proto field names (snake_case) alongside camelCase *)
+  let json = `Assoc [ ("sm_string", `String "hello proto name") ] in
+  let msg = decode_json_small_message json in
+  assert (msg.sm_string = "hello proto name");
+
+  (* Also verify camelCase still works *)
+  let json2 = `Assoc [ ("smString", `String "hello camel case") ] in
+  let msg2 = decode_json_small_message json2 in
+  assert (msg2.sm_string = "hello camel case");
+
+  print_endline "\nProto field name decode ... Ok"

--- a/src/tests/yojson/yojson_unittest_ml.ml
+++ b/src/tests/yojson/yojson_unittest_ml.ml
@@ -138,12 +138,12 @@ let () =
 let () =
   let open Yojson_unittest in
   (* Decoder must accept proto field names (snake_case) alongside camelCase *)
-  let json = `Assoc [ ("sm_string", `String "hello proto name") ] in
+  let json = `Assoc [ "sm_string", `String "hello proto name" ] in
   let msg = decode_json_small_message json in
   assert (msg.sm_string = "hello proto name");
 
   (* Also verify camelCase still works *)
-  let json2 = `Assoc [ ("smString", `String "hello camel case") ] in
+  let json2 = `Assoc [ "smString", `String "hello camel case" ] in
   let msg2 = decode_json_small_message json2 in
   assert (msg2.sm_string = "hello camel case");
 


### PR DESCRIPTION
improve json conformance, and add `Decoder.offset` as well as `Decoder.of_subbytes`.

close #265 
