### PR TITLE
Accept whitespace and comments inside a qualified name (#255)

### DIFF
--- a/src/compilerlib/pb_parsing.ml
+++ b/src/compilerlib/pb_parsing.ml
@@ -63,10 +63,12 @@ let string_of_token =
   | T_semi -> ";"
   | T_colon -> ":"
   | T_comma -> ","
+  | T_dot -> "."
   | T_string s -> Printf.sprintf "%S" s
   | T_int i -> string_of_int i
   | T_float f -> string_of_float f
   | T_ident (_, s) -> s
+  | T_dot_ident (_, s) -> s
   | T_eof -> "<EOF>"
 
 (* Custom lexer that buffers tokens *)

--- a/src/compilerlib/pb_parsing_lexer.mll
+++ b/src/compilerlib/pb_parsing_lexer.mll
@@ -90,9 +90,13 @@ let update_loc lexbuf =
 let start_letter  = ['a'-'z' 'A'-'Z' '_']
 let identchar     = ['A'-'Z' 'a'-'z' '_' '0'-'9']
 let ident         = start_letter identchar *
-let full_ident    = '.' ? ident ("." * ident) *
-(* let message_type  = '.' ? (ident '.') ident
- *)
+(* A dotted name with no internal whitespace, lexed as a single token so that a
+ * keyword appearing as an inner segment (a.map.C) stays part of the name and an
+ * underscore segment (a._b) is not mangled. Whitespace or comments around a dot
+ * split the name into several tokens, which [qualified_ident] rejoins.
+ **)
+let ident_path     = ident ("." ident) *
+let dot_ident_path = '.' ident ("." ident) *
 let int_litteral  = ['+' '-']? ['0'-'9']+
 let hex_litteral = ['+' '-']? "0x" ['0'-'9' 'a'-'f' 'A'-'F']+
 let inf_litteral  = ['+' '-']? "inf"
@@ -120,6 +124,11 @@ rule lexer = parse
   | ";"         { T_semi }
   | ":"         { T_colon }
   | ","         { T_comma }
+  (* Must precede [float_literal], which also matches a lone "." since all of
+   * its parts are optional; on an equal-length match ocamllex prefers the rule
+   * defined first.
+   **)
+  | "."         { T_dot }
   | "//"        { match comment [] lexbuf with
     | Comment_eof     -> T_eof
     | Comment_value _ -> lexer lexbuf
@@ -138,7 +147,8 @@ rule lexer = parse
   | inf_litteral  { T_float nan }
   | newline       { update_loc lexbuf; lexer lexbuf }
   | blank         { lexer lexbuf }
-  | full_ident    { resolve_identifier (Loc.from_lexbuf lexbuf) (Lexing.lexeme lexbuf) }
+  | ident_path    { resolve_identifier (Loc.from_lexbuf lexbuf) (Lexing.lexeme lexbuf) }
+  | dot_ident_path { T_dot_ident (Loc.from_lexbuf lexbuf, Lexing.lexeme lexbuf) }
   | eof           { T_eof }
   | _             { failwith @@ Printf.sprintf "Unknown character found %s" @@
   Lexing.lexeme lexbuf}

--- a/src/compilerlib/pb_parsing_parser.mly
+++ b/src/compilerlib/pb_parsing_parser.mly
@@ -59,10 +59,12 @@
 %token T_semi
 %token T_colon
 %token T_comma
+%token T_dot
 %token <string> T_string
 %token <int>    T_int
 %token <float>  T_float
 %token <Pb_location.t * string> T_ident
+%token <Pb_location.t * string> T_dot_ident
 %token T_eof
 
 /*Entry points*/
@@ -153,7 +155,7 @@ import:
   | T_import T_ident T_string semicolon   { Pb_exception.invalid_import_qualifier $1 } /*HT*/
 
 package_declaration :
-  | T_package T_ident semicolon {snd $2}
+  | T_package qualified_ident semicolon {$2}
 
 message :
   | T_message T_ident T_lbrace message_body_content_list rbrace {
@@ -178,11 +180,11 @@ message_body_content :
   | option       { Pb_parsing_util.message_body_option $1 }
 
 extend :
-  | T_extend T_ident T_lbrace normal_field_list rbrace {
-    Pb_parsing_util.extend (snd $2) $4
+  | T_extend qualified_ident T_lbrace normal_field_list rbrace {
+    Pb_parsing_util.extend $2 $4
   }
-  | T_extend T_ident T_lbrace rbrace {
-    Pb_parsing_util.extend (snd $2) []
+  | T_extend qualified_ident T_lbrace rbrace {
+    Pb_parsing_util.extend $2 []
   }
 
 normal_field_list :
@@ -212,9 +214,35 @@ service_body_content :
   | rpc          { Pb_parsing_util.service_body_rpc $1 }
   | option       { Pb_parsing_util.service_body_option $1 }
 
+/* (* A type or package name, possibly dotted and possibly rooted with a
+    * leading dot. protobuf treats whitespace and comments as insignificant
+    * between the pieces of such a name, so "a.b.C", "a.b .C" and "a . b . C"
+    * all name the same type, as do ".a.b.C" and ". a.b.C". A leading dot is
+    * NOT redundant: it roots the name at the top level scope, which
+    * Pb_field_type records as [from_root], so ".a.b.C" and "a.b.C" are
+    * different names.
+    *
+    * The lexer emits one token per unbroken dotted run, so a name split by
+    * whitespace or a comment arrives as several tokens; concatenating their
+    * lexemes rebuilds the dotted string the rest of the compiler expects,
+    * leading dot included.
+    *
+    * Only the first segment may be a bare identifier: a continuation has to
+    * start with a dot, which is what keeps "T_ident field_name" (a type
+    * followed by a field name) unambiguous. *) */
+qualified_ident :
+  | T_ident qualified_ident_tail        { snd $1 ^ $2 }
+  | T_dot_ident qualified_ident_tail    { snd $1 ^ $2 }
+  | T_dot field_name qualified_ident_tail { "." ^ $2 ^ $3 }
+
+qualified_ident_tail :
+  |                                     { "" }
+  | T_dot_ident qualified_ident_tail    { snd $1 ^ $2 }
+  | T_dot field_name qualified_ident_tail { "." ^ $2 ^ $3 }
+
 message_type :
-  | T_stream T_ident { (true, snd $2) }
-  | T_ident { (false, snd $1) }
+  | T_stream qualified_ident { (true, $2) }
+  | qualified_ident { (false, $1) }
 
 rpc :
   | T_rpc T_ident T_lparen message_type T_rparen T_returns T_lparen message_type T_rparen semicolon {
@@ -284,37 +312,37 @@ oneof_field_list :
   | oneof_field oneof_field_list        { $1::$2 }
 
 oneof_field :
-  | T_ident field_name T_equal T_int field_options semicolon {
-    Pb_parsing_util.oneof_field ~type_:(snd $1) ~number:$4 ~options:$5 $2
+  | qualified_ident field_name T_equal T_int field_options semicolon {
+    Pb_parsing_util.oneof_field ~type_:$1 ~number:$4 ~options:$5 $2
   }
-  | T_ident field_name T_equal T_int semicolon {
-    Pb_parsing_util.oneof_field ~type_:(snd $1) ~number:$4 $2
+  | qualified_ident field_name T_equal T_int semicolon {
+    Pb_parsing_util.oneof_field ~type_:$1 ~number:$4 $2
   }
   | option     { Pb_parsing_util.oneof_option $1 }
 
 map :
-  | T_map T_less T_ident T_comma T_ident T_greater field_name T_equal T_int semicolon {
+  | T_map T_less qualified_ident T_comma qualified_ident T_greater field_name T_equal T_int semicolon {
     Pb_parsing_util.map_field
-        ~key_type:(snd $3) ~value_type:(snd $5) ~number:$9 $7
+        ~key_type:$3 ~value_type:$5 ~number:$9 $7
   }
-  | T_map T_less T_ident T_comma T_ident T_greater field_name T_equal T_int field_options semicolon {
+  | T_map T_less qualified_ident T_comma qualified_ident T_greater field_name T_equal T_int field_options semicolon {
     Pb_parsing_util.map_field
-        ~options:$10 ~key_type:(snd $3) ~value_type:(snd $5) ~number:$9 $7
+        ~options:$10 ~key_type:$3 ~value_type:$5 ~number:$9 $7
   }
 
 normal_field :
-  | label T_ident field_name T_equal T_int field_options semicolon {
-    Pb_parsing_util.field ~label:$1 ~type_:(snd $2) ~number:$5 ~options:$6 $3
+  | label qualified_ident field_name T_equal T_int field_options semicolon {
+    Pb_parsing_util.field ~label:$1 ~type_:$2 ~number:$5 ~options:$6 $3
   }
-  | label T_ident field_name T_equal T_int semicolon {
-    Pb_parsing_util.field ~label:$1 ~type_:(snd $2) ~number:$5 $3
+  | label qualified_ident field_name T_equal T_int semicolon {
+    Pb_parsing_util.field ~label:$1 ~type_:$2 ~number:$5 $3
   }
-  | T_ident field_name T_equal T_int field_options semicolon {
+  | qualified_ident field_name T_equal T_int field_options semicolon {
     Pb_parsing_util.field
-        ~label:`Nolabel ~type_:(snd $1) ~number:$4 ~options:$5 $2
+        ~label:`Nolabel ~type_:$1 ~number:$4 ~options:$5 $2
   }
-  | T_ident field_name T_equal T_int semicolon {
-    Pb_parsing_util.field ~label:`Nolabel ~type_:(snd $1) ~number:$4 $2
+  | qualified_ident field_name T_equal T_int semicolon {
+    Pb_parsing_util.field ~label:`Nolabel ~type_:$1 ~number:$4 $2
   }
 
 field_name :
@@ -331,6 +359,7 @@ field_name :
   | T_extensions{"extensions"}
   | T_extend    {"extend"}
   | T_reserved  {"reserved"}
+  | T_returns   {"returns"}
   | T_syntax    {"syntax"}
   | T_message   {"message"}
   | T_service   {"service"}
@@ -363,7 +392,8 @@ field_option :
 
 option_identifier_item :
   | T_ident                       {snd $1 |> Pb_parsing_util.option_name_of_ident}
-  | T_lparen T_ident T_rparen     {snd $2 |> Pb_parsing_util.option_name_extension}
+  | T_dot_ident                   {snd $1 |> Pb_parsing_util.option_name_of_ident}
+  | T_lparen qualified_ident T_rparen {$2 |> Pb_parsing_util.option_name_extension}
 
 option_identifier :
   | option_identifier_item    {$1}

--- a/src/tests/unit-tests/dune
+++ b/src/tests/unit-tests/dune
@@ -3,6 +3,6 @@
  (names graph_test format_play_ground lexer_comment ocaml_codegen_test
    parse_enum pbtt_compile_p2 test_typing verify_syntax_invariants
    parse_message parse_field_options parse_file_options parse_import
-   pbtt_compile_p1 backend_ocaml_test)
+   pbtt_compile_p1 backend_ocaml_test parse_qualified_ident)
  (libraries pbrt ocaml-protoc.compiler-lib)
  (flags :standard -open Ocaml_protoc_compiler_lib))

--- a/src/tests/unit-tests/parse_qualified_ident.ml
+++ b/src/tests/unit-tests/parse_qualified_ident.ml
@@ -1,0 +1,162 @@
+let parse f s = f Pb_parsing_lexer.lexer (Lexing.from_string s)
+
+module Pt = Pb_parsing_parse_tree
+
+let field_type s = (parse Pb_parsing_parser.normal_field_ s).Pt.field_type
+
+(* protobuf treats whitespace and comments as insignificant, so each of these
+ * spellings names the same type as the canonical "a.b.c.Inner". *)
+let () =
+  let canonical = field_type "a.b.c.Inner f = 1;" in
+  List.iter
+    (fun spelling -> assert (field_type spelling = canonical))
+    [
+      "a.b.c\n      .Inner f = 1;";
+      "a.b.c .Inner f = 1;";
+      "a.b.c. Inner f = 1;";
+      "a . b . c . Inner f = 1;";
+      "a.b.c // trailing comment\n      .Inner f = 1;";
+      "a.b.c /* inline comment */ .Inner f = 1;";
+      "a\n  .b\n  .c\n  .Inner f = 1;";
+    ]
+
+(* the path segments and the leading dot (which marks a name resolved from the
+ * root scope) both survive being split up *)
+let () =
+  assert (
+    field_type "a . b . C f = 1;"
+    = `User_defined
+        {
+          Pb_field_type.type_path = [ "a"; "b" ];
+          type_name = "C";
+          from_root = false;
+        });
+  assert (
+    field_type ". a.b.C f = 1;"
+    = `User_defined
+        {
+          Pb_field_type.type_path = [ "a"; "b" ];
+          type_name = "C";
+          from_root = true;
+        })
+
+(* a keyword is a legal path segment, split or not *)
+let () =
+  assert (field_type "a . map . C f = 1;" = field_type "a.map.C f = 1;");
+  assert (field_type "a . to . C f = 1;" = field_type "a.to.C f = 1;");
+  assert (field_type "a . returns . C f = 1;" = field_type "a.returns.C f = 1;")
+
+(* builtin types keep resolving to their builtin, and are not turned into a
+ * single segment user defined name *)
+let () =
+  assert (field_type "int32 f = 1;" = `Int32);
+  assert (field_type "string f = 1;" = `String)
+
+(* a name may be split in any other position a type is named *)
+let () =
+  let proto = parse Pb_parsing_parser.proto_ "package a . b . c;" in
+  assert (proto.Pt.package = Some "a.b.c")
+
+let oneof_field_type s =
+  match (parse Pb_parsing_parser.oneof_ s).Pt.oneof_body with
+  | [ Pt.Oneof_field field ] -> field.Pt.field_type
+  | [] | Pt.Oneof_option _ :: _ | _ :: _ :: _ -> assert false
+
+(* both oneof field forms, with and without field options *)
+let () =
+  let expected =
+    `User_defined
+      { Pb_field_type.type_path = [ "p" ]; type_name = "V"; from_root = false }
+  in
+  assert (oneof_field_type "oneof o { p\n  . V v = 1; }" = expected);
+  assert (
+    oneof_field_type "oneof o { p . V v = 1 [deprecated = true]; }" = expected)
+
+(* every labelled and optioned normal_field form names its type the same way *)
+let () =
+  let expected =
+    `User_defined
+      { Pb_field_type.type_path = [ "a"; "b" ]; type_name = "C"; from_root = false }
+  in
+  List.iter
+    (fun spelling -> assert (field_type spelling = expected))
+    [
+      "a . b . C f = 1;";
+      "a . b . C f = 1 [deprecated = true];";
+      "optional a . b . C f = 1;";
+      "repeated a . b . C f = 1 [deprecated = true];";
+    ]
+
+(* the unsplit leading dot form reaches qualified_ident through its dot leading
+ * token, rather than through a detached dot *)
+let () =
+  assert (
+    field_type ".a.b.C f = 1;"
+    = `User_defined
+        {
+          Pb_field_type.type_path = [ "a"; "b" ];
+          type_name = "C";
+          from_root = true;
+        })
+
+(* a map value type *)
+let map_value_type s =
+  match (parse Pb_parsing_parser.message_ s).Pt.message_body with
+  | [ Pt.Message_map_field field ] -> field.Pt.map_value_type
+  | []
+  | _ :: _ :: _
+  | ( Pt.Message_field _ | Pt.Message_oneof_field _ | Pt.Message_sub _
+    | Pt.Message_enum _ | Pt.Message_extension _ | Pt.Message_reserved _
+    | Pt.Message_option _ )
+    :: _ ->
+    assert false
+
+let () =
+  assert (
+    map_value_type "message M { map<string, p . V> m = 1; }"
+    = map_value_type "message M { map<string,p.V> m = 1; }")
+
+(* an rpc request and response type *)
+let rpc_types s =
+  match (parse Pb_parsing_parser.service_ s).Pt.service_body with
+  | [ Pt.Service_rpc rpc ] -> rpc.Pt.rpc_req, rpc.Pt.rpc_res
+  | [] | _ :: _ :: _ | Pt.Service_option _ :: _ -> assert false
+
+let () =
+  assert (
+    rpc_types "service S { rpc Go (a . b . Req) returns (. c.Res); }"
+    = rpc_types "service S { rpc Go (a.b.Req) returns (.c.Res); }")
+
+(* an extend target *)
+let () =
+  let extend =
+    parse Pb_parsing_parser.extend_ "extend p . Foo { optional int32 b = 100; }"
+  in
+  assert (extend.Pt.extend_name = "p.Foo")
+
+(* a parenthesised option extension name, and the dot leading continuation that
+ * "option (ext).sub" depends on *)
+let () =
+  assert (
+    parse Pb_parsing_parser.option_ "option (a . b) = 1;"
+    = parse Pb_parsing_parser.option_ "option (a.b) = 1;");
+  let name, _ = parse Pb_parsing_parser.option_ "option (ext).sub = 1;" in
+  assert (
+    name
+    = [ Pb_raw_option.Extension_name "ext"; Pb_raw_option.Simple_name "sub" ])
+
+(* An empty segment, a trailing dot and a lone dot are all parse errors, and
+ * must be reported as such: a lone dot used to be matched by the float literal
+ * rule and escaped as Failure "float_of_string" rather than a parse error. *)
+let rejected s =
+  match parse Pb_parsing_parser.normal_field_ s with
+  | _ -> false
+  | exception Failure _ -> false
+  | exception Parsing.Parse_error -> true
+
+let () =
+  assert (rejected "a..b.C f = 1;");
+  assert (rejected "a.b.c. = 1;");
+  assert (rejected "int32 . = 1;")
+
+let () = print_endline "Parse Qualified Ident ... Ok"


### PR DESCRIPTION
## Summary

Fixes #255. A qualified type name split across lines or spaces, the shape that appears throughout
the googleapis `.proto` files, failed to parse. `protoc` treats whitespace and comments as
insignificant between the segments of a dotted name; `ocaml-protoc` did not.

The example from #255 (`google/ads/googleads/v18/services/google_ads_service.proto`) now compiles:

```proto
repeated google.ads.googleads.v18.resources
    .OfflineConversionUploadConversionActionSummary
        offline_conversion_upload_conversion_action_summary = 228;
```

## Problem

`pb_parsing_lexer.mll` lexed an entire dotted name as one token:

```ocaml
let full_ident = '.' ? ident ("." * ident) *
```

and there was no rule for `.` at all, so every qualified-name position in the grammar was spelled as
a single `T_ident`. A name broken by whitespace therefore arrived as several tokens and no production
matched.  Measured against `protoc` 23.2, every one of these is accepted by `protoc` and rejected
before this change:

| input | before |
|---|---|
| `a.b.c` NL `.Inner f = 1;` | `Parsing error` (the reported case) |
| `a.b.c .Inner f = 1;` | `Parsing error` |
| `a.b.c. Inner f = 1;` | `Failure("float_of_string")` |
| `a . b . c . Inner f = 1;` | `Failure("float_of_string")` |
| `. a.b.c.Inner f = 1;` | `Failure("float_of_string")` |
| `a.b.c //c` NL `.Inner f = 1;` | `Parsing error` |
| `a.b.c /*c*/ .Inner f = 1;` | `Parsing error` |

The same breakage applied to every other position that names a type: `package a . b . c;`, rpc
request/response types, `map` value types, `extend` targets, and oneof field types.

Two things fall out of the same root cause and are fixed here too:

- **A lone `.` raised an uncaught exception rather than a parse error.** `float_literal` has every
  part optional, so it matched a bare `.` and `float_of_string "."` raised. `message M { int32 . = 1; }`
  reported `Failure("float_of_string")` with a location pointing at unrelated earlier text.  It now
  reports a normal `Parsing error` at the right place.
- **Five dot-leading spellings were silently accepted where `protoc` rejects them**, because a
  leading dot was absorbed into an ordinary identifier: a declared message name `.Foo`, a field name
  `.y`, an enum value `.A`, a constant `.foo`, and an option message-literal key `.k`.  Lexing a
  dot-leading name as its own token makes all five parse errors, matching `protoc`.
- **An empty path segment was silently accepted.** `a..b.C` parsed, and the empty segment leaked
  downstream as an empty type: the old error was `unresolved type for field name : f (type:, ...)`
  with a blank type.  `protoc` rejects `a..b.C`;  so does this change, as a parse error.

## Fix

Make `.` a real token and rejoin the segments in the grammar, rather than widening the lexer regexp.
A regexp cannot span case `a.b.c /*c*/ .Inner`, because the comment is consumed by a separate lexer
rule.

- `pb_parsing_lexer.mll`: split `full_ident` into `ident_path` (no leading dot) and `dot_ident_path`
  (leading dot, emitted as the new `T_dot_ident`), and add a rule for a bare `.` emitting the new
  `T_dot`. The `"."` rule sits with the other punctuation, ahead of `float_literal`, since
  `float_literal` also matches a lone `.` and ocamllex resolves an equal-length tie in favour of the
  earlier rule.  Tightening `("." * ident) *` to `("." ident) *` is what rejects the empty segment.
- `pb_parsing_parser.mly`: add `qualified_ident` / `qualified_ident_tail`, which rebuild the dotted
  string by concatenating the pieces' lexemes.  **Only the first piece may be a bare identifier;  every
  continuation must begin with a dot.** That asymmetry is what keeps the `TYPE fieldname` adjacency
  unambiguous, and `ocamlyacc` reports zero shift/reduce and zero reduce/reduce conflicts.
  The post-dot segment is `field_name`, so a keyword remains legal as a path segment.
- `qualified_ident` is then used at the positions that name a type: `normal_field`, `oneof_field`,
  `map` key and value, `message_type` (rpc), `package_declaration`, `extend`, and the parenthesised
  option extension name.  Declared names (message, enum, service, rpc, field, oneof, enum value) are
  deliberately left as plain `T_ident`, since protobuf allows only a simple name there.
- `option_identifier_item` also accepts `T_dot_ident`, so `option (ext).sub = v` keeps working, since it
  relied on `.sub` lexing as a `T_ident`.
- `field_name` gains a `T_returns` alternative.  It already listed every other keyword that
  `resolve_identifier` produces, and `returns` was the only one missing, so without it `a . returns . C`
  would be the one split path that still failed.  As a side effect this also lets a field be named
  `returns`, which `protoc` allows and `ocaml-protoc` previously rejected.
- `pb_parsing.ml`: render the two new tokens in `string_of_token` (used for the error context).

Keeping an unbroken dotted run as a *single* token is deliberate: it is what preserves a keyword as
an inner segment (`a.map.C`, `a.to.C`) and leaves `a._priv.C` unmangled, both of which work today
and would regress under a scheme that lexed every segment separately.

## Testing

- New unit test `src/tests/unit-tests/parse_qualified_ident.ml` asserts that seven split spellings
  parse to *the same* `field_type` structure as the canonical `a.b.c.Inner`, that the path segments
  and the `from_root` leading-dot marker survive, that a keyword segment works split or not, that
  builtins still resolve to builtins, that a split name works in a `package` declaration and a oneof
  field, and that `a..b.C`, a trailing dot and a lone dot are all rejected *as parse errors* rather
  than as `Failure`.
- Every hunk of the change is mutation-confirmed: a battery of **16 mutations**, each reverting one
  hunk on its own (each qualified-name position, each `normal_field` and `oneof_field` label/option
  variant, the `T_returns` alternative, dropping the leading dot, making the continuation
  non-recursive, and dropping the dot between segments), is caught by the new test.  No mutation
  survives.  An earlier round of this battery is what caught that the map, rpc, `extend` and
  option-name positions were initially asserted by nothing.
- `dune build @runtest --force`: all existing tests pass unchanged, including `Google unittest`
  (which parses Google's real `descriptor.proto` and `unittest.proto`).
- Codegen is unchanged: running the before and after binaries over every `.proto` under `src/`
  (49 files) gives byte-identical generated `.ml`/`.mli` for the 37 that compile (76 files), and
  the identical error message for the 12 that do not.
- Differentially checked against `protoc` 23.2 over 33 inputs covering whitespace and comments in
  every qualified-name position, keyword and underscore segments, the dotted option-name forms, and
  float/int/hex literals: agreement went from 16/33 to 29/33, and the four remaining rows are cases
  where `protoc` errors for a *semantic* reason (an undefined option extension) while `ocaml-protoc`
  only parses, i.e. they confirm nothing regressed.

## Known limitations

Three things I deliberately left alone, all pre-existing and orthogonal to #255.  Happy to follow up
on any of them separately.

Whitespace around a dot inside an **option name** is still a parse error, so `option a . b = 1;` and
`option (ext) . sub = 1;` still fail while `protoc` parses both (its complaint about them is the
semantic `Option "a" unknown`).  Option names are assembled by a different mechanism,
`option_identifier`, which concatenates adjacent items rather than going through `qualified_ident`.
Only the unbroken and dot-leading spellings are supported, as before.

A whitespace-split segment spelled `e1` or `E1` still escapes as `Failure("float_of_string")`, and
one spelled `inf` lexes as a float, so `a . e1 . C` and `a . inf . C` are rejected where `protoc`
accepts them.  That is the pre-existing float-literal-versus-identifier ambiguity the lexer already
flags in its own `TODO fix: somehow E1 for field identified get lexed into a float` comment; the same
inputs failed before this change, and fixing it means tightening `float_literal`, which felt like a
separate change.

A non-first path segment beginning with `_` is treated differently when the name is split, because
`resolve_identifier` mangles a standalone lexeme starting with `_` to `p` + lexeme: `a._priv.C` gives
segment `_priv`, while `a . _priv . C` gives `p_priv`. Before this change the split spelling was a
hard crash, and the remaining failure mode is a loud "unresolved type" error rather than silent
corruption, so I left that pre-existing mangling rule alone rather than widen the diff.

I did not touch `CHANGES.md`, since it looks like entries are added there in the `prepare for <version>`
release commits rather than per PR, but glad to add one if you prefer.

---

*AI assistance disclosure: this change was developed with AI assistance (Claude). The design was
chosen after differentially testing candidate approaches against `protoc` as an oracle, and all
results reported above were produced by running the builds and the test suite locally.*
