### PR TITLE
Decode empty messages tolerantly, skipping unknown fields (#250)

### DIFF
--- a/ocaml-protoc.opam
+++ b/ocaml-protoc.opam
@@ -30,6 +30,7 @@ build: [
     "@install"
     "@src/examples/runtest" {with-test}
     "@src/tests/expectation/runtest" {with-test}
+    "@src/tests/integration-tests/runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/ocaml-protoc.opam.template
+++ b/ocaml-protoc.opam.template
@@ -10,6 +10,7 @@ build: [
     "@install"
     "@src/examples/runtest" {with-test}
     "@src/tests/expectation/runtest" {with-test}
+    "@src/tests/integration-tests/runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/src/compilerlib/pb_codegen_decode_binary.ml
+++ b/src/compilerlib/pb_codegen_decode_binary.ml
@@ -267,10 +267,10 @@ let gen_unit ?and_ { Ot.er_name } sc =
     er_name;
   F.sub_scope sc (fun sc ->
       F.line sc "match Pbrt.Decoder.key d with";
-      F.line sc "| None -> ();";
-      F.line sc "| Some (_, pk) -> ";
-      F.linep sc "  Pbrt.Decoder.unexpected_payload \"%s\" pk"
-        (sp "Unexpected fields in empty message(%s)" er_name))
+      F.line sc "| None -> ()";
+      F.line sc "| Some (_, pk) ->";
+      F.line sc "  Pbrt.Decoder.skip d pk;";
+      F.linep sc "  decode_pb_%s d" er_name)
 
 let gen_variant ?and_ { Ot.v_name; v_constructors; v_use_polyvariant = _ } sc =
   let process_ctor sc variant_constructor =

--- a/src/examples/build_server.ml.expected
+++ b/src/examples/build_server.ml.expected
@@ -87,9 +87,10 @@ let rec decode_pb_file_path d =
 
 let rec decode_pb_empty d =
   match Pbrt.Decoder.key d with
-  | None -> ();
-  | Some (_, pk) -> 
-    Pbrt.Decoder.unexpected_payload "Unexpected fields in empty message(empty)" pk
+  | None -> ()
+  | Some (_, pk) ->
+    Pbrt.Decoder.skip d pk;
+    decode_pb_empty d
 
 [@@@ocaml.warning "-23-27-30-39"]
 

--- a/src/examples/calculator.ml.expected
+++ b/src/examples/calculator.ml.expected
@@ -177,9 +177,10 @@ let rec encode_pb_empty (v:empty) encoder =
 
 let rec decode_pb_div_by_zero d =
   match Pbrt.Decoder.key d with
-  | None -> ();
-  | Some (_, pk) -> 
-    Pbrt.Decoder.unexpected_payload "Unexpected fields in empty message(div_by_zero)" pk
+  | None -> ()
+  | Some (_, pk) ->
+    Pbrt.Decoder.skip d pk;
+    decode_pb_div_by_zero d
 
 let rec decode_pb_i32 d =
   let v = default_i32 () in
@@ -238,9 +239,10 @@ let rec decode_pb_add_all_req d =
 
 let rec decode_pb_empty d =
   match Pbrt.Decoder.key d with
-  | None -> ();
-  | Some (_, pk) -> 
-    Pbrt.Decoder.unexpected_payload "Unexpected fields in empty message(empty)" pk
+  | None -> ()
+  | Some (_, pk) ->
+    Pbrt.Decoder.skip d pk;
+    decode_pb_empty d
 
 [@@@ocaml.warning "-23-27-30-39"]
 

--- a/src/examples/file_server.ml.expected
+++ b/src/examples/file_server.ml.expected
@@ -265,21 +265,24 @@ let rec decode_pb_file_crc d =
 
 let rec decode_pb_empty d =
   match Pbrt.Decoder.key d with
-  | None -> ();
-  | Some (_, pk) -> 
-    Pbrt.Decoder.unexpected_payload "Unexpected fields in empty message(empty)" pk
+  | None -> ()
+  | Some (_, pk) ->
+    Pbrt.Decoder.skip d pk;
+    decode_pb_empty d
 
 let rec decode_pb_ping d =
   match Pbrt.Decoder.key d with
-  | None -> ();
-  | Some (_, pk) -> 
-    Pbrt.Decoder.unexpected_payload "Unexpected fields in empty message(ping)" pk
+  | None -> ()
+  | Some (_, pk) ->
+    Pbrt.Decoder.skip d pk;
+    decode_pb_ping d
 
 let rec decode_pb_pong d =
   match Pbrt.Decoder.key d with
-  | None -> ();
-  | Some (_, pk) -> 
-    Pbrt.Decoder.unexpected_payload "Unexpected fields in empty message(pong)" pk
+  | None -> ()
+  | Some (_, pk) ->
+    Pbrt.Decoder.skip d pk;
+    decode_pb_pong d
 
 [@@@ocaml.warning "-23-27-30-39"]
 

--- a/src/runtime/pbrt.ml
+++ b/src/runtime/pbrt.ml
@@ -224,7 +224,7 @@ module Decoder = struct
 
   let skip d kind =
     let skip_len n =
-      if d.offset + n > d.limit then
+      if n < 0 || n > d.limit - d.offset then
         raise (Failure Incomplete)
       else
         d.offset <- d.offset + n
@@ -269,10 +269,10 @@ module Decoder = struct
 
   let empty_nested d =
     let len = int_as_varint d in
-    if len <> 0 then
+    if len < 0 || len > d.limit - d.offset then
       raise (Failure Incomplete)
     else
-      ()
+      d.offset <- d.offset + len
 
   let packed_fold f e0 d =
     let d' = nested d in

--- a/src/runtime/pbrt.mli
+++ b/src/runtime/pbrt.mli
@@ -117,8 +117,13 @@ module Decoder : sig
   val map_entry : t -> decode_key:(t -> 'a) -> decode_value:(t -> 'b) -> 'a * 'b
 
   val empty_nested : t -> unit
-  (** [empty_nested d] skips an empty message of 0 length. If reading the
-      message would exhaust input of [d], raises [Failure Incomplete]. *)
+  (** [empty_nested d] reads the length prefix of a nested message and skips
+      the payload bytes, ignoring any content. A message the current schema
+      knows as empty may carry fields written by a newer schema; protobuf
+      unknown-field semantics require them to be ignored (issue #250). Raises
+      [Failure Incomplete] if the length prefix cannot be read, or if the
+      declared length is negative or exceeds the remaining input, and
+      [Failure Overlong_varint] on a malformed length prefix. *)
 
   val packed_fold : ('a -> t -> 'a) -> 'a -> t -> 'a
   (** [packed_fold f e0 d] folds over the a packed encoding with [f acc d] and

--- a/src/tests/integration-tests/dune
+++ b/src/tests/integration-tests/dune
@@ -377,7 +377,8 @@
  (action
   (run ocaml-protoc --binary --pp --ml_out ./ %{proto})))
 
-(executable
+(test
  (name test29_ml)
+ (package ocaml-protoc)
  (libraries pbrt)
  (modules test29_ml test29))

--- a/src/tests/integration-tests/test29_ml.ml
+++ b/src/tests/integration-tests/test29_ml.ml
@@ -20,6 +20,64 @@ let test_num_roundtrip () =
   let v' = T.decode_pb_outer dec in
   assert (v = v')
 
+(* #250: an "empty" message may carry fields written by a newer schema;
+ * the generated decoder must skip them, not raise.
+ * 21-byte protoc-validated payload: varint 150, len-2 "hi", fixed32 7,
+ * fixed64 9 *)
+let evolved_payload =
+  "\x08\x96\x01\x12\x02\x68\x69\x1d\x07\x00\x00\x00\x21\x09\x00\x00\x00\x00\x00\x00\x00"
+
+(* same payload truncated to its first 20 bytes: the final fixed64 is
+ * one byte short *)
+let evolved_payload_truncated =
+  "\x08\x96\x01\x12\x02\x68\x69\x1d\x07\x00\x00\x00\x21\x09\x00\x00\x00\x00\x00\x00"
+
+let check name ok =
+  if ok then
+    ()
+  else (
+    print_endline ("FAIL: " ^ name);
+    exit 1
+  )
+
+let raises_incomplete f =
+  try
+    f ();
+    false
+  with Pbrt.Decoder.Failure Pbrt.Decoder.Incomplete -> true
+
+let test_empty_decode_evolved () =
+  (* generated decoder for the empty message skips unknown fields *)
+  let dec = Pbrt.Decoder.of_string evolved_payload in
+  let () = T.decode_pb_empty dec in
+  check "empty decode evolved" (Pbrt.Decoder.key dec = None)
+
+let test_empty_decode_truncated () =
+  let dec = Pbrt.Decoder.of_string evolved_payload_truncated in
+  check "empty decode truncated raises Incomplete"
+    (raises_incomplete (fun () -> T.decode_pb_empty dec))
+
+let test_outer_oneof_empty_evolved () =
+  (* oneof arm [empty] is field 2 in test29.proto: tag byte
+   * (2 lsl 3) lor 2 = 0x12, then length 0x15 = 21 *)
+  let dec = Pbrt.Decoder.of_string ("\x12\x15" ^ evolved_payload) in
+  check "outer oneof empty evolved" (T.decode_pb_outer dec = T.Empty)
+
+let test_outer_oneof_empty_maxint_len () =
+  (* oneof arm [empty] tagged 0x12, then a 9-byte varint length that
+   * decodes to exactly max_int: an addition-form bound check would wrap
+   * negative and silently accept this malformed message (pre-fix PoC
+   * returned Empty); the subtraction-form guard must raise Incomplete *)
+  let dec =
+    Pbrt.Decoder.of_string "\x12\xff\xff\xff\xff\xff\xff\xff\xff\x3f"
+  in
+  check "outer oneof empty max_int length raises Incomplete"
+    (raises_incomplete (fun () -> ignore (T.decode_pb_outer dec)))
+
 let () =
   test_empty_roundtrip ();
-  test_num_roundtrip ()
+  test_num_roundtrip ();
+  test_empty_decode_evolved ();
+  test_empty_decode_truncated ();
+  test_outer_oneof_empty_evolved ();
+  test_outer_oneof_empty_maxint_len ()

--- a/src/tests/unit-tests/pbrt/dune
+++ b/src/tests/unit-tests/pbrt/dune
@@ -1,5 +1,5 @@
 (tests
  (package pbrt)
- (names pbrt_array wrapper_encoding varint decoder_offset)
+ (names pbrt_array wrapper_encoding varint decoder_offset empty_nested)
  (libraries pbrt)
  (flags :standard))

--- a/src/tests/unit-tests/pbrt/empty_nested.ml
+++ b/src/tests/unit-tests/pbrt/empty_nested.ml
@@ -1,0 +1,78 @@
+module D = Pbrt.Decoder
+
+(* 21-byte protoc-validated EmptyEvolved payload:
+ * varint 150, len-2 "hi", fixed32 7, fixed64 9 *)
+let payload =
+  "\x08\x96\x01\x12\x02\x68\x69\x1d\x07\x00\x00\x00\x21\x09\x00\x00\x00\x00\x00\x00\x00"
+
+(* same payload truncated to its first 20 bytes: the final fixed64 is
+ * one byte short *)
+let payload_truncated =
+  "\x08\x96\x01\x12\x02\x68\x69\x1d\x07\x00\x00\x00\x21\x09\x00\x00\x00\x00\x00\x00"
+
+let check name ok =
+  if ok then
+    ()
+  else (
+    print_endline ("FAIL: " ^ name);
+    exit 1
+  )
+
+let raises_incomplete f =
+  try
+    f ();
+    false
+  with D.Failure D.Incomplete -> true
+
+(* zero-length empty message: succeeds, input exhausted *)
+let () =
+  let d = D.of_string "\x00" in
+  D.empty_nested d;
+  check "zero-length" (D.key d = None)
+
+(* empty message carrying unknown fields from a newer schema:
+ * succeeds and consumes the whole payload *)
+let () =
+  let d = D.of_string ("\x15" ^ payload) in
+  D.empty_nested d;
+  check "evolved payload skipped" (D.key d = None)
+
+(* same, nested one level down as field 1 with wire type 2 *)
+let () =
+  let d = D.of_string ("\x0a\x15" ^ payload) in
+  check "nested framing key" (D.key d = Some (1, Pbrt.Bytes));
+  D.empty_nested d;
+  check "nested framing exhausted" (D.key d = None)
+
+(* truncated payload: declared length exceeds remaining input *)
+let () =
+  let d = D.of_string ("\x15" ^ payload_truncated) in
+  check "truncated raises Incomplete"
+    (raises_incomplete (fun () -> D.empty_nested d))
+
+(* hostile 10-byte varint length 2^64-1 wraps to -1 through
+ * Int64.to_int: caught by the negative-length guard *)
+let () =
+  let d = D.of_string "\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01" in
+  check "negative length raises Incomplete"
+    (raises_incomplete (fun () -> D.empty_nested d))
+
+(* overflow neighbor of the negative case: the 9-byte varint decodes
+ * through Int64.to_int to exactly max_int, which stays POSITIVE, so an
+ * addition-form bound check (offset + len > limit) would wrap negative
+ * and silently pass; only the subtraction form catches it *)
+let () =
+  let d = D.of_string "\xff\xff\xff\xff\xff\xff\xff\xff\x3f" in
+  check "max_int length raises Incomplete"
+    (raises_incomplete (fun () -> D.empty_nested d))
+
+(* skip-side twin: this 9-byte varint decodes through Int64.to_int to
+ * exactly -10, so an unguarded skip_len would move the offset BACKWARDS
+ * (silently returning unit here, an infinite loop in generated skip
+ * loops); the negative guard must turn it into Incomplete *)
+let () =
+  let d = D.of_string "\xf6\xff\xff\xff\xff\xff\xff\xff\x7f" in
+  check "negative skip length raises Incomplete"
+    (raises_incomplete (fun () -> D.skip d Pbrt.Bytes))
+
+let () = print_endline "empty_nested tests passed"


### PR DESCRIPTION
## Summary

Fixes the remaining defect discussed in #250.  Decoding a message the schema knows as empty now ignores unknown fields, per protobuf forward-compatibility semantics, instead of raising.

The original service-stub wiring reported in #250 was already fixed on master (service stubs use `encode_pb_empty` / `decode_pb_empty`, as @Lupus confirmed in the thread).  What remained is the strictness @c-cube called out: "The protobuf semantics is that unexpected fields should just be ignored, not that we should enforce the absence of any field."

## Problem

Two decode paths enforced emptiness:

- Runtime: `Pbrt.Decoder.empty_nested` read the length prefix and raised `Failure Incomplete` unless it was exactly 0.  Every nested position for an empty message routes through it: message field, map value, oneof arm, standalone variant.
- Codegen: the generated top-level `decode_pb_<empty>` raised `Pbrt.Decoder.unexpected_payload` on the first field it saw.

Consequence: schema evolution breaks deployed decoders.  If a peer's `Empty` message gains a field, every existing OCaml consumer hard-fails on payloads that all conformant implementations accept (protoc ignores the unknown field;  protoc 23.2 was used as an accept/reject oracle for the tests below).

## Fix

- `src/runtime/pbrt.ml`: `Decoder.empty_nested` reads the varint length and skips that many payload bytes, raising `Failure Incomplete` if the declared length is negative or exceeds the remaining input.  Because this lives in the runtime, already-generated user code picks up the fix at link time, without regeneration.
- `src/compilerlib/pb_codegen_decode_binary.ml` (`gen_unit`): the generated top-level decoder is now a tail-recursive skip-all loop:

  ```ocaml
  let rec decode_pb_empty d =
    match Pbrt.Decoder.key d with
    | None -> ()
    | Some (_, pk) ->
      Pbrt.Decoder.skip d pk;
      decode_pb_empty d
  ```

- `src/runtime/pbrt.ml`: `Decoder.skip` now rejects a negative length.  This is required by the change above rather than incidental to it.  A length prefix is decoded through `Int64.to_int`, so a 9-byte varint can present as a negative native `int`;  `skip` previously moved the decoder offset *backwards* on such input, which turns the new skip-all loop into a non-terminating spin on a 10-byte message.  The same weakness already let a crafted message hang the generated record, variant and map decoders, so the guard fixes those too.
- Both bounds checks are written as `len > d.limit - d.offset` rather than `d.offset + len > d.limit`.  The addition form overflows: a 9-byte varint decodes to as much as `max_int`, so the sum wraps negative, the check passes, and the decoder silently accepts a message declaring a payload it does not have.  The subtraction form compares two small non-negative quantities and cannot wrap.
- Encoder side untouched: `Encoder.empty_nested` still writes a length of 0, which is the correct wire form.
- Example goldens regenerated for the three affected files: `build_server.ml.expected`, `calculator.ml.expected`, `file_server.ml.expected`.

## Testing

- New runtime unit test `src/tests/unit-tests/pbrt/empty_nested.ml`.  The unknown-field payload it uses carries one field of each wire type (varint, length-delimited, fixed32, fixed64) and was validated against a protoc 23.2 accept/reject oracle.  Vectors: the length-0 case (previous behavior preserved);  the payload accepted and fully consumed;  the same payload nested one level deeper;  a truncation whose declared length exceeds the remaining input (still raises `Incomplete`);  a 10-byte varint that wraps to a negative length;  a 9-byte varint that stays positive at `max_int`, which is the case an addition-form bound check would miss;  and a negative-length `skip`, which is the non-terminating case above.
- Generated-code regression cases in `src/tests/integration-tests/test29_ml.ml`: `decode_pb_empty` accepts the unknown-field payload and rejects the truncation, `decode_pb_outer` on a oneof arm carrying `Empty` with unknown fields returns the `Empty` case (exercising the runtime path end to end), and the `max_int`-length message is rejected rather than silently accepted.
- While wiring these up we found `test29_ml` was a bare `(executable)` that no harness ran, so the existing #267 roundtrip test never executed under `dune runtest`.  It is now a `(test)`, and `@src/tests/integration-tests/runtest` was added to the `ocaml-protoc` package's test aliases so `opam install -t` runs it as well.
- Every behavioral hunk was confirmed by mutation: reverting it individually turns a named test red.
- Full suite: the failing set is identical before and after this change (the pre-existing `./x.proto` header diffs in `src/examples/*.mli.expected`, which are environmental).

## Scope notes

- Binary decode path only.  The BuckleScript backend (`pb_codegen_decode_bs.ml`, `gen_unit`) currently emits `failwith "support for empty messages not implemented"` and is unchanged here.  JSON decode paths are also unchanged, and rejecting unknown fields there is spec-conformant for canonical protobuf JSON.
- `Decoder.bytes`, `nested` and `string` carry the same addition-form overflow that `empty_nested` and `skip` are fixed for here.  They are not reachable through this issue's paths and fail fast on `Bytes.sub`'s own bounds check rather than corrupting decoder state, so they are left alone;  happy to fold them in if you would prefer one sweep.
- Groups (wire types 3 and 4) remain unsupported (`Decoder.key` raises `Malformed_field`), which is conformant for proto3.
- `CHANGES.md` deliberately untouched (repo convention: edited in release-preparation commits).  Suggested release-notes bullet: `Decoder.empty_nested` and generated empty-message decoders now skip unknown fields instead of raising, and `Decoder.skip` rejects a negative length (#250).

## AI assistance disclosure

This PR was developed with AI assistance (Claude).  All changes were human-reviewed before submission, the test vectors were validated against protoc 23.2 as an independent oracle, and every behavioral hunk is pinned by a test that was observed to fail under mutation of that hunk.
