### PR TITLE
json: honor the json_name field option (#158)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 
 ## 4.1
 
+- json: honor the `json_name` field option in the yojson and bs backends. The
+  encoders emit it in place of the camelCased field name, and the decoders
+  accept it alongside the original proto field name (#158)
+- json: the bs decoder now accepts the original proto field name (snake_case)
+  as well as the camelCase one, as the yojson decoder already did
 - bugfix for large signed int64 in pbrt
 - fix misunderstanding about defaults
 - fix `Rfp_wrapped_option` (when number of optionals > `max_bits` in very large messages)

--- a/src/compilerlib/pb_codegen_decode_bs.ml
+++ b/src/compilerlib/pb_codegen_decode_bs.ml
@@ -3,6 +3,28 @@ module F = Pb_codegen_formatting
 
 let sp = Pb_codegen_util.sp
 
+(* Emit a field name pattern that matches both the JSON name of the field and
+   its original proto field name (snake_case), as required by the ProtoJSON
+   spec. The JSON name is the [json_name] option when the .proto file sets one,
+   and the camelCased proto name otherwise; in the former case the camelCased
+   name is deliberately NOT accepted, since json_name replaces it. *)
+let field_name_pattern json_label proto_label =
+  if json_label = proto_label then
+    sp "\"%s\"" json_label
+  else
+    sp "(\"%s\" | \"%s\")" json_label proto_label
+
+(* Same, for the arms that then look the value up in the JSON object. Returns
+   the pattern along with the expression holding the key that matched: when the
+   two spellings differ it is not known statically which one the object carries,
+   so the matched key has to be bound. The binding is only introduced when it is
+   used, to avoid an unused-variable warning in the generated code. *)
+let field_name_pattern_with_key json_label proto_label =
+  if json_label = proto_label then
+    sp "\"%s\"" json_label, sp "\"%s\"" json_label
+  else
+    sp "((\"%s\" | \"%s\") as key)" json_label proto_label, "key"
+
 let value_expression ~r_name ~rf_label field_type =
   let basic_type helper_fun =
     sp "Pbrt_bs.%s json \"%s\" \"%s\"" helper_fun r_name rf_label
@@ -44,26 +66,26 @@ let value_expression ~r_name ~rf_label field_type =
 (* | _ -> assert(false) *)
 
 (* Generate the pattern match for a record field *)
-let gen_rft_nolabel sc ~r_name ~rf_label (field_type, _, _) =
-  let json_label = Pb_codegen_util.camel_case_of_label rf_label in
+let gen_rft_nolabel sc ~r_name ~json_label ~rf_label (field_type, _, _) =
+  let name_pat, key_exp = field_name_pattern_with_key json_label rf_label in
   let value_expression = value_expression ~r_name ~rf_label field_type in
 
-  F.linep sc "| \"%s\" -> " json_label;
-  F.linep sc "  let json = Js.Dict.unsafeGet json \"%s\" in" json_label;
+  F.linep sc "| %s -> " name_pat;
+  F.linep sc "  let json = Js.Dict.unsafeGet json %s in" key_exp;
   F.linep sc "  v.%s <- %s" rf_label value_expression
 
 (* Generate all the pattern matches for a repeated field *)
-let gen_rft_repeated sc ~r_name ~rf_label repeated_field =
+let gen_rft_repeated sc ~r_name ~json_label ~rf_label repeated_field =
   let _, field_type, _, _, _ = repeated_field in
 
-  let json_label = Pb_codegen_util.camel_case_of_label rf_label in
+  let name_pat, key_exp = field_name_pattern_with_key json_label rf_label in
 
-  F.linep sc "| \"%s\" -> begin" json_label;
+  F.linep sc "| %s -> begin" name_pat;
 
   F.sub_scope sc (fun sc ->
       F.line sc "let a = ";
       F.sub_scope sc (fun sc ->
-          F.linep sc "let a = Js.Dict.unsafeGet json \"%s\" in " json_label;
+          F.linep sc "let a = Js.Dict.unsafeGet json %s in " key_exp;
           F.linep sc "Pbrt_bs.array_ a \"%s\" \"%s\"" r_name rf_label);
       F.line sc "in";
       F.linep sc "v.%s <- Array.map (fun json -> " rf_label;
@@ -74,31 +96,37 @@ let gen_rft_repeated sc ~r_name ~rf_label repeated_field =
 
   F.line sc "end"
 
-let gen_rft_optional sc ~r_name ~rf_label optional_field =
+let gen_rft_optional sc ~r_name ~json_label ~rf_label optional_field =
   let field_type, _, _, _ = optional_field in
 
-  let json_label = Pb_codegen_util.camel_case_of_label rf_label in
+  let name_pat, key_exp = field_name_pattern_with_key json_label rf_label in
   let value_expression = value_expression ~r_name ~rf_label field_type in
 
-  F.linep sc "| \"%s\" -> " json_label;
-  F.linep sc "  let json = Js.Dict.unsafeGet json \"%s\" in" json_label;
+  F.linep sc "| %s -> " name_pat;
+  F.linep sc "  let json = Js.Dict.unsafeGet json %s in" key_exp;
   F.linep sc "  v.%s <- Some (%s)" rf_label value_expression
 
 (* Generate pattern match for a variant field *)
 let gen_rft_variant sc ~r_name ~rf_label { Ot.v_constructors; _ } =
   List.iter
-    (fun { Ot.vc_constructor; vc_field_type; _ } ->
+    (fun { Ot.vc_constructor; vc_field_type; vc_options; _ } ->
       let json_label =
-        Pb_codegen_util.camel_case_of_constructor vc_constructor
+        Pb_codegen_util.json_label_of_constructor vc_options vc_constructor
       in
+      let proto_label = String.lowercase_ascii vc_constructor in
 
       match vc_field_type with
       | Ot.Vct_nullary ->
-        F.linep sc "| \"%s\" -> v.%s <- %s" json_label rf_label vc_constructor
+        F.linep sc "| %s -> v.%s <- %s"
+          (field_name_pattern json_label proto_label)
+          rf_label vc_constructor
       | Ot.Vct_non_nullary_constructor field_type ->
+        let name_pat, key_exp =
+          field_name_pattern_with_key json_label proto_label
+        in
         let value_expression = value_expression ~r_name ~rf_label field_type in
-        F.linep sc "| \"%s\" -> " json_label;
-        F.linep sc "  let json = Js.Dict.unsafeGet json \"%s\" in" json_label;
+        F.linep sc "| %s -> " name_pat;
+        F.linep sc "  let json = Js.Dict.unsafeGet json %s in" key_exp;
         F.linep sc "  v.%s <- %s (%s)" rf_label vc_constructor value_expression)
     v_constructors
 
@@ -117,14 +145,17 @@ let gen_record ?and_ { Ot.r_name; r_fields } sc =
 
           (* Generate pattern match for all the possible message field *)
           List.iter
-            (fun { Ot.rf_label; rf_field_type; _ } ->
+            (fun { Ot.rf_label; rf_field_type; rf_options; _ } ->
+              let json_label =
+                Pb_codegen_util.json_label_of_label rf_options rf_label
+              in
               match rf_field_type with
               | Ot.Rft_nolabel nolabel_field ->
-                gen_rft_nolabel sc ~r_name ~rf_label nolabel_field
+                gen_rft_nolabel sc ~r_name ~json_label ~rf_label nolabel_field
               | Ot.Rft_optional optional_field ->
-                gen_rft_optional sc ~r_name ~rf_label optional_field
+                gen_rft_optional sc ~r_name ~json_label ~rf_label optional_field
               | Ot.Rft_repeated repeated_field ->
-                gen_rft_repeated sc ~r_name ~rf_label repeated_field
+                gen_rft_repeated sc ~r_name ~json_label ~rf_label repeated_field
               | Ot.Rft_variant variant_field ->
                 gen_rft_variant sc ~r_name ~rf_label variant_field
               | Ot.Rft_required _ ->
@@ -152,20 +183,29 @@ let gen_record ?and_ { Ot.r_name; r_fields } sc =
 (* Generate decode function for a variant type *)
 let gen_variant ?and_ { Ot.v_name; v_constructors; v_use_polyvariant = _ } sc =
   (* helper function for each constructor case *)
-  let process_v_constructor sc { Ot.vc_constructor; vc_field_type; _ } =
-    let json_label = Pb_codegen_util.camel_case_of_constructor vc_constructor in
+  let process_v_constructor sc
+      { Ot.vc_constructor; vc_field_type; vc_options; _ } =
+    let json_label =
+      Pb_codegen_util.json_label_of_constructor vc_options vc_constructor
+    in
+    let proto_label = String.lowercase_ascii vc_constructor in
 
     match vc_field_type with
     | Ot.Vct_nullary ->
-      F.linep sc "| \"%s\" -> (%s : %s)" json_label vc_constructor v_name
+      F.linep sc "| %s -> (%s : %s)"
+        (field_name_pattern json_label proto_label)
+        vc_constructor v_name
     | Ot.Vct_non_nullary_constructor field_type ->
+      let name_pat, key_exp =
+        field_name_pattern_with_key json_label proto_label
+      in
       let value_expression =
         let r_name = v_name and rf_label = vc_constructor in
         value_expression ~r_name ~rf_label field_type
       in
 
-      F.linep sc "| \"%s\" -> " json_label;
-      F.linep sc "  let json = Js.Dict.unsafeGet json \"%s\" in" json_label;
+      F.linep sc "| %s -> " name_pat;
+      F.linep sc "  let json = Js.Dict.unsafeGet json %s in" key_exp;
       F.linep sc "  (%s (%s) : %s)" vc_constructor value_expression v_name
   in
 

--- a/src/compilerlib/pb_codegen_decode_yojson.ml
+++ b/src/compilerlib/pb_codegen_decode_yojson.ml
@@ -3,8 +3,11 @@ module F = Pb_codegen_formatting
 
 let sp = Pb_codegen_util.sp
 
-(* Emit a field name pattern that matches both the camelCase json_name and the
-   original proto field name (snake_case), as required by the ProtoJSON spec. *)
+(* Emit a field name pattern that matches both the JSON name of the field and
+   its original proto field name (snake_case), as required by the ProtoJSON
+   spec. The JSON name is the [json_name] option when the .proto file sets one,
+   and the camelCased proto name otherwise; in the former case the camelCased
+   name is deliberately NOT accepted, since json_name replaces it. *)
 let field_name_pattern json_label proto_label =
   if json_label = proto_label then
     sp "\"%s\"" json_label
@@ -47,8 +50,7 @@ let field_pattern_match ~r_name ~rf_label field_type =
   | _ -> assert false
 
 (* Generate all the pattern matches for a record field *)
-let gen_rft_nolabel sc ~r_name ~rf_label (field_type, _, _) =
-  let json_label = Pb_codegen_util.camel_case_of_label rf_label in
+let gen_rft_nolabel sc ~r_name ~json_label ~rf_label (field_type, _, _) =
   let name_pat = field_name_pattern json_label rf_label in
 
   let match_variable_name, exp =
@@ -58,10 +60,9 @@ let gen_rft_nolabel sc ~r_name ~rf_label (field_type, _, _) =
   F.linep sc "  %s_set_%s v (%s)" r_name rf_label exp
 
 (* Generate all the pattern matches for a repeated field *)
-let gen_rft_repeated_field sc ~r_name ~rf_label repeated_field =
+let gen_rft_repeated_field sc ~r_name ~json_label ~rf_label repeated_field =
   let _, field_type, _, _, _ = repeated_field in
 
-  let json_label = Pb_codegen_util.camel_case_of_label rf_label in
   let name_pat = field_name_pattern json_label rf_label in
 
   F.linep sc "| (%s, `List l) -> begin" name_pat;
@@ -76,10 +77,9 @@ let gen_rft_repeated_field sc ~r_name ~rf_label repeated_field =
 
   F.line sc "end"
 
-let gen_rft_optional_field sc ~r_name ~rf_label optional_field =
+let gen_rft_optional_field sc ~r_name ~json_label ~rf_label optional_field =
   let field_type, _, _, _ = optional_field in
 
-  let json_label = Pb_codegen_util.camel_case_of_label rf_label in
   let name_pat = field_name_pattern json_label rf_label in
 
   let match_variable_name, exp =
@@ -92,9 +92,9 @@ let gen_rft_optional_field sc ~r_name ~rf_label optional_field =
 (* Generate pattern match for a variant field *)
 let gen_rft_variant_field sc ~r_name ~rf_label { Ot.v_constructors; _ } =
   List.iter
-    (fun { Ot.vc_constructor; vc_field_type; _ } ->
+    (fun { Ot.vc_constructor; vc_field_type; vc_options; _ } ->
       let json_label =
-        Pb_codegen_util.camel_case_of_constructor vc_constructor
+        Pb_codegen_util.json_label_of_constructor vc_options vc_constructor
       in
       let proto_label = String.lowercase_ascii vc_constructor in
       let name_pat = field_name_pattern json_label proto_label in
@@ -111,8 +111,8 @@ let gen_rft_variant_field sc ~r_name ~rf_label { Ot.v_constructors; _ } =
         F.linep sc "  %s_set_%s v (%s (%s))" r_name rf_label vc_constructor exp)
     v_constructors
 
-let gen_rft_assoc_field sc ~r_name ~rf_label ~assoc_type ~key_type ~value_type =
-  let json_label = Pb_codegen_util.camel_case_of_label rf_label in
+let gen_rft_assoc_field sc ~r_name ~json_label ~rf_label ~assoc_type ~key_type
+    ~value_type =
   let name_pat = field_name_pattern json_label rf_label in
   F.linep sc "| (%s, `Assoc assoc) ->" name_pat;
   F.sub_scope sc (fun sc ->
@@ -170,23 +170,28 @@ let gen_record ?and_ { Ot.r_name; r_fields } sc =
       F.sub_scope sc (fun sc ->
           (* Generate pattern match for all the possible message field *)
           List.iter
-            (fun { Ot.rf_label; rf_field_type; _ } ->
+            (fun { Ot.rf_label; rf_field_type; rf_options; _ } ->
+              let json_label =
+                Pb_codegen_util.json_label_of_label rf_options rf_label
+              in
               match rf_field_type with
               | Ot.Rft_nolabel nolabel_field ->
-                gen_rft_nolabel sc ~r_name ~rf_label nolabel_field
+                gen_rft_nolabel sc ~r_name ~json_label ~rf_label nolabel_field
               | Ot.Rft_repeated repeated_field ->
-                gen_rft_repeated_field sc ~r_name ~rf_label repeated_field
+                gen_rft_repeated_field sc ~r_name ~json_label ~rf_label
+                  repeated_field
               | Ot.Rft_variant variant_field ->
                 gen_rft_variant_field sc ~r_name ~rf_label variant_field
               | Ot.Rft_optional optional_field ->
-                gen_rft_optional_field sc ~r_name ~rf_label optional_field
+                gen_rft_optional_field sc ~r_name ~json_label ~rf_label
+                  optional_field
               | Ot.Rft_required _ ->
                 Printf.eprintf "Only proto3 syntax supported in JSON encoding";
                 exit 1
               | Ot.Rft_associative
                   (assoc_type, _, (key_type, _), (value_type, _)) ->
-                gen_rft_assoc_field sc ~r_name ~rf_label ~assoc_type ~key_type
-                  ~value_type)
+                gen_rft_assoc_field sc ~r_name ~json_label ~rf_label ~assoc_type
+                  ~key_type ~value_type)
             r_fields;
 
           (* Unknown fields are simply ignored *)
@@ -219,8 +224,11 @@ let gen_unit ?and_ { Ot.er_name } sc =
 (* Generate decode function for a variant type *)
 let gen_variant ?and_ { Ot.v_name; v_constructors; v_use_polyvariant = _ } sc =
   (* helper function for each constructor case *)
-  let process_v_constructor sc { Ot.vc_constructor; vc_field_type; _ } =
-    let json_label = Pb_codegen_util.camel_case_of_constructor vc_constructor in
+  let process_v_constructor sc
+      { Ot.vc_constructor; vc_field_type; vc_options; _ } =
+    let json_label =
+      Pb_codegen_util.json_label_of_constructor vc_options vc_constructor
+    in
     let proto_label = String.lowercase_ascii vc_constructor in
     let name_pat = field_name_pattern json_label proto_label in
 

--- a/src/compilerlib/pb_codegen_encode_bs.ml
+++ b/src/compilerlib/pb_codegen_encode_bs.ml
@@ -89,28 +89,23 @@ let gen_field sc var_name json_label field_type pk =
         F.linep sc "| Some __x__ -> %s" statement);
     F.line sc "end;"
 
-let gen_rft_nolabel sc var_name rf_label (field_type, _, pk) =
-  let json_label = Pb_codegen_util.camel_case_of_label rf_label in
+let gen_rft_nolabel sc ~json_label var_name (field_type, _, pk) =
   gen_field sc var_name json_label field_type pk
 
-let gen_rft_optional sc var_name rf_label (field_type, _, pk, _) =
+let gen_rft_optional sc ~json_label var_name (field_type, _, pk, _) =
   F.linep sc "begin match %s with" var_name;
   F.line sc "| None -> ()";
   F.line sc "| Some v ->";
-  F.sub_scope sc (fun sc ->
-      let json_label = Pb_codegen_util.camel_case_of_label rf_label in
-      gen_field sc "v" json_label field_type pk);
+  F.sub_scope sc (fun sc -> gen_field sc "v" json_label field_type pk);
   F.line sc "end;"
 
-let gen_rft_repeated sc var_name rf_label repeated_field =
+let gen_rft_repeated sc ~json_label var_name rf_label repeated_field =
   let repeated_type, field_type, _, pk, _ = repeated_field in
   (match repeated_type with
   | Ot.Rt_list -> ()
   | Ot.Rt_repeated_field ->
     sp "Pbrt.Repeated_field is not supported with JSON (field: %s)" rf_label
     |> failwith);
-
-  let json_label = Pb_codegen_util.camel_case_of_label rf_label in
 
   F.linep sc "begin match %s with" var_name;
   F.line sc "| [] -> ()";
@@ -157,10 +152,16 @@ let gen_rft_variant sc var_name rf_label { Ot.v_constructors; _ } =
   F.linep sc "begin match %s with" var_name;
   F.sub_scope sc (fun sc ->
       List.iter
-        (fun { Ot.vc_constructor; vc_field_type; vc_payload_kind; _ } ->
+        (fun {
+               Ot.vc_constructor;
+               vc_field_type;
+               vc_payload_kind;
+               vc_options;
+               _;
+             } ->
           let var_name = "v" in
           let json_label =
-            Pb_codegen_util.camel_case_of_constructor vc_constructor
+            Pb_codegen_util.json_label_of_constructor vc_options vc_constructor
           in
           F.linep sc "| %s v ->" vc_constructor;
           F.sub_scope sc (fun sc ->
@@ -181,18 +182,21 @@ let gen_record ?and_ { Ot.r_name; r_fields } sc =
       F.line sc "let json = Js.Dict.empty () in";
       List.iter
         (fun record_field ->
-          let { Ot.rf_label; rf_field_type; _ } = record_field in
+          let { Ot.rf_label; rf_field_type; rf_options; _ } = record_field in
           let var_name = sp "v.%s" rf_label in
+          let json_label =
+            Pb_codegen_util.json_label_of_label rf_options rf_label
+          in
 
           match rf_field_type with
           | Ot.Rft_nolabel nolabel_field ->
-            gen_rft_nolabel sc var_name rf_label nolabel_field
+            gen_rft_nolabel sc ~json_label var_name nolabel_field
           | Ot.Rft_repeated repeated_field ->
-            gen_rft_repeated sc var_name rf_label repeated_field
+            gen_rft_repeated sc ~json_label var_name rf_label repeated_field
           | Ot.Rft_variant variant_field ->
             gen_rft_variant sc var_name rf_label variant_field
           | Ot.Rft_optional optional_field ->
-            gen_rft_optional sc var_name rf_label optional_field
+            gen_rft_optional sc ~json_label var_name optional_field
           | Ot.Rft_required _ ->
             Printf.eprintf "Only proto3 syntax supported in JSON encoding";
             exit 1
@@ -204,11 +208,19 @@ let gen_record ?and_ { Ot.r_name; r_fields } sc =
 
 let gen_variant ?and_ { Ot.v_name; v_constructors; v_use_polyvariant = _ } sc =
   let process_v_constructor sc v_constructor =
-    let { Ot.vc_constructor; Ot.vc_field_type; Ot.vc_payload_kind; _ } =
+    let {
+      Ot.vc_constructor;
+      Ot.vc_field_type;
+      Ot.vc_payload_kind;
+      Ot.vc_options;
+      _;
+    } =
       v_constructor
     in
 
-    let json_label = Pb_codegen_util.camel_case_of_constructor vc_constructor in
+    let json_label =
+      Pb_codegen_util.json_label_of_constructor vc_options vc_constructor
+    in
 
     match vc_field_type with
     | Ot.Vct_nullary ->

--- a/src/compilerlib/pb_codegen_encode_yojson.ml
+++ b/src/compilerlib/pb_codegen_encode_yojson.ml
@@ -68,23 +68,21 @@ let gen_field var_name json_label field_type pk : string option =
     Some (sp "(\"%s\", %s %s)" json_label f_name var_name)
   | _ -> assert false
 
-let gen_rft_nolabel sc rf_label (field_type, _, pk) =
+let gen_rft_nolabel sc ~json_label rf_label (field_type, _, pk) =
   let var_name = sp "v.%s" rf_label in
-  let json_label = Pb_codegen_util.camel_case_of_label rf_label in
   match gen_field var_name json_label field_type pk with
   | None -> ()
   | Some exp -> F.linep sc "assoc := %s :: !assoc;" exp
 
-let gen_rft_optional sc rf_label (field_type, _, pk, _) =
+let gen_rft_optional sc ~json_label rf_label (field_type, _, pk, _) =
   F.linep sc "assoc := (match v.%s with" rf_label;
   F.sub_scope sc (fun sc ->
       F.line sc "| None -> !assoc";
-      let json_label = Pb_codegen_util.camel_case_of_label rf_label in
       match gen_field "v" json_label field_type pk with
       | None -> F.line sc "| Some v -> !assoc"
       | Some exp -> F.linep sc "| Some v -> %s :: !assoc);" exp)
 
-let gen_rft_repeated sc rf_label repeated_field =
+let gen_rft_repeated sc ~json_label rf_label repeated_field =
   let repeated_type, field_type, _, pk, _ = repeated_field in
   (match repeated_type with
   | Ot.Rt_list -> ()
@@ -93,7 +91,6 @@ let gen_rft_repeated sc rf_label repeated_field =
     |> failwith);
 
   let var_name = sp "v.%s" rf_label in
-  let json_label = Pb_codegen_util.camel_case_of_label rf_label in
 
   F.line sc "assoc := (";
   F.sub_scope sc (fun sc ->
@@ -128,10 +125,16 @@ let gen_rft_variant sc rf_label { Ot.v_constructors; _ } =
   F.sub_scope sc (fun sc ->
       F.line sc "  | None -> !assoc";
       List.iter
-        (fun { Ot.vc_constructor; vc_field_type; vc_payload_kind; _ } ->
+        (fun {
+               Ot.vc_constructor;
+               vc_field_type;
+               vc_payload_kind;
+               vc_options;
+               _;
+             } ->
           let var_name = "v" in
           let json_label =
-            Pb_codegen_util.camel_case_of_constructor vc_constructor
+            Pb_codegen_util.json_label_of_constructor vc_options vc_constructor
           in
           F.sub_scope sc (fun sc ->
               match vc_field_type with
@@ -151,10 +154,9 @@ let gen_rft_variant sc rf_label { Ot.v_constructors; _ } =
 
   F.linep sc "); (* match v.%s *)" rf_label
 
-let gen_rft_assoc sc ~rf_label ~assoc_type ~key_type
+let gen_rft_assoc sc ~json_label ~rf_label ~assoc_type ~key_type
     ~value_field:(value_type, value_pk) =
   let var_name = sp "v.%s" rf_label in
-  let json_label = Pb_codegen_util.camel_case_of_label rf_label in
   let key_pat, key_exp =
     match key_type with
     | Ot.Bt_string -> "key", "key"
@@ -218,7 +220,12 @@ let gen_record ?and_ { Ot.r_name; r_fields } sc =
       F.line sc "let assoc = ref [] in";
       List.iter
         (fun record_field ->
-          let { Ot.rf_label; rf_field_type; rf_presence; _ } = record_field in
+          let { Ot.rf_label; rf_field_type; rf_presence; rf_options; _ } =
+            record_field
+          in
+          let json_label =
+            Pb_codegen_util.json_label_of_label rf_options rf_label
+          in
 
           let in_bitfield =
             match rf_presence with
@@ -231,19 +238,20 @@ let gen_record ?and_ { Ot.r_name; r_fields } sc =
           F.sub_scope_if in_bitfield sc (fun sc ->
               match rf_field_type with
               | Ot.Rft_nolabel nolabel_field ->
-                gen_rft_nolabel sc rf_label nolabel_field
+                gen_rft_nolabel sc ~json_label rf_label nolabel_field
               | Ot.Rft_repeated repeated_field ->
-                gen_rft_repeated sc rf_label repeated_field
+                gen_rft_repeated sc ~json_label rf_label repeated_field
               | Ot.Rft_variant variant_field ->
                 gen_rft_variant sc rf_label variant_field
               | Ot.Rft_optional optional_field ->
-                gen_rft_optional sc rf_label optional_field
+                gen_rft_optional sc ~json_label rf_label optional_field
               | Ot.Rft_required _ ->
                 Printf.eprintf "Only proto3 syntax supported in JSON encoding";
                 exit 1
               | Ot.Rft_associative (assoc_type, _, (key_type, _), value_field)
                 ->
-                gen_rft_assoc sc ~rf_label ~assoc_type ~key_type ~value_field);
+                gen_rft_assoc sc ~json_label ~rf_label ~assoc_type ~key_type
+                  ~value_field);
 
           if in_bitfield then F.line sc ");")
         r_fields (* List.iter *);
@@ -258,11 +266,19 @@ let gen_unit ?and_ { Ot.er_name } sc =
 
 let gen_variant ?and_ { Ot.v_name; v_constructors; v_use_polyvariant = _ } sc =
   let process_v_constructor sc v_constructor =
-    let { Ot.vc_constructor; Ot.vc_field_type; Ot.vc_payload_kind; _ } =
+    let {
+      Ot.vc_constructor;
+      Ot.vc_field_type;
+      Ot.vc_payload_kind;
+      Ot.vc_options;
+      _;
+    } =
       v_constructor
     in
 
-    let json_label = Pb_codegen_util.camel_case_of_constructor vc_constructor in
+    let json_label =
+      Pb_codegen_util.json_label_of_constructor vc_options vc_constructor
+    in
 
     match vc_field_type with
     | Ot.Vct_nullary ->

--- a/src/compilerlib/pb_codegen_util.ml
+++ b/src/compilerlib/pb_codegen_util.ml
@@ -155,6 +155,33 @@ let camel_case_of_label s =
 
 let camel_case_of_constructor s = camel_case_of_label (String.lowercase_ascii s)
 
+(* The .proto [json_name] option, when it is set to a string constant. protoc
+   keeps this on the descriptor rather than in the option set, but this compiler
+   parses .proto files itself and stores every option verbatim, so it surfaces
+   here as a plain (non extension) option name.
+
+   Any other shape of value is ignored rather than rejected, the way the rest of
+   the compiler treats options it does not recognise. *)
+let json_name_of_options options =
+  Pb_option.get options (Pb_option.Simple_name "json_name")
+  |> Option.map (function
+       | Pb_option.Scalar_value (Pb_option.Constant_string s) -> Some s
+       | Pb_option.Scalar_value (Pb_option.Constant_bool _)
+       | Pb_option.Scalar_value (Pb_option.Constant_int _)
+       | Pb_option.Scalar_value (Pb_option.Constant_float _)
+       | Pb_option.Scalar_value (Pb_option.Constant_literal _)
+       | Pb_option.Message_literal _ | Pb_option.List_literal _ ->
+         None)
+  |> Option.join
+
+let json_label_of_label options label =
+  json_name_of_options options
+  |> Option.value ~default:(camel_case_of_label label)
+
+let json_label_of_constructor options constructor =
+  json_name_of_options options
+  |> Option.value ~default:(camel_case_of_constructor constructor)
+
 let collect_modules_of_field_type modules = function
   | Ot.Ft_user_defined_type { Ot.udt_module_prefix = Some m; _ } -> m :: modules
   | _ -> modules

--- a/src/compilerlib/pb_codegen_util.mli
+++ b/src/compilerlib/pb_codegen_util.mli
@@ -62,6 +62,22 @@ val camel_case_of_constructor : string -> string
 (** this function transform an OCaml constructuror `Like_this` into a 'likeThis'
     case *)
 
+val json_label_of_label : Pb_option.set -> string -> string
+(** [json_label_of_label options label] returns the JSON name of the field named
+    [label] in the .proto file. This is the value of the field's [json_name]
+    option when it is set to a string, and [camel_case_of_label label]
+    otherwise, as specified by
+    {{:https://protobuf.dev/programming-guides/json/} ProtoJSON}.
+
+    A [json_name] whose value is not a string constant is ignored rather than
+    rejected, matching how the rest of the compiler treats options it does not
+    recognise. *)
+
+val json_label_of_constructor : Pb_option.set -> string -> string
+(** [json_label_of_constructor options constructor] is
+    [json_label_of_label options] applied to the .proto name of the [oneof] case
+    whose OCaml constructor is [constructor]. *)
+
 val collect_modules_of_types : Pb_codegen_ocaml_type.type_ list -> string list
 (** [collect_modules_of_types ocaml_types] return the list of all the modules
     that the [ocaml_types] depends on *)

--- a/src/tests/yojson/yojson_unittest.proto
+++ b/src/tests/yojson/yojson_unittest.proto
@@ -85,3 +85,15 @@ message NestedUnit {
 
   string other = 3;
 }
+
+// The [json_name] option replaces the camelCased JSON key of a field, both
+// when encoding and when decoding. See https://protobuf.dev/programming-guides/json/
+message JsonName {
+  string renamed_field = 1 [json_name = "custom_JSON_name"];
+  string plain_field = 2;
+
+  oneof choice {
+    string renamed_case = 3 [json_name = "customCase"];
+    string plain_case = 4;
+  }
+}

--- a/src/tests/yojson/yojson_unittest_ml.ml
+++ b/src/tests/yojson/yojson_unittest_ml.ml
@@ -148,3 +148,73 @@ let () =
   assert (msg2.sm_string = "hello camel case");
 
   print_endline "\nProto field name decode ... Ok"
+
+(* [json_name] REPLACES the camelCased JSON key rather than adding to it, so the
+   accepted spellings of a renamed field are the json_name and the original
+   proto field name, and NOT the camelCase the field would otherwise have had.
+   Cross-checked against protoc 23.2 and the protobuf 7.35.1 Python runtime. *)
+let () =
+  let open Yojson_unittest in
+  let failures = ref [] in
+  let check name passed = if not passed then failures := name :: !failures in
+
+  let assoc_of_json = function
+    | `Assoc assoc -> assoc
+    | `Null | `Bool _ | `Int _ | `Float _ | `String _ | `List _ -> []
+  in
+  let key assoc k = List.assoc_opt k assoc in
+
+  (* encoding uses the json_name, and the camelCased name for every other
+     field *)
+  let encoded =
+    make_json_name ~renamed_field:"r" ~plain_field:"p"
+      ~choice:(Renamed_case "c") ()
+    |> encode_json_json_name |> assoc_of_json
+  in
+  check "encode uses json_name"
+    (key encoded "custom_JSON_name" = Some (`String "r"));
+  check "encode camelCases an un-renamed field"
+    (key encoded "plainField" = Some (`String "p"));
+  check "encode uses json_name for a oneof case"
+    (key encoded "customCase" = Some (`String "c"));
+  check "encode does not also emit the camelCased name"
+    (key encoded "renamedField" = None);
+
+  let decode json = decode_json_json_name json in
+
+  (* decoding accepts the json_name and the original proto field name *)
+  check "decode accepts json_name"
+    ((decode (`Assoc [ "custom_JSON_name", `String "x" ])).renamed_field = "x");
+  check "decode accepts the proto field name"
+    ((decode (`Assoc [ "renamed_field", `String "x" ])).renamed_field = "x");
+  (* but not the camelCase the field would have had without the option: that is
+     an unknown field, and unknown fields are ignored *)
+  check "decode rejects the superseded camelCase name"
+    ((decode (`Assoc [ "renamedField", `String "x" ])).renamed_field = "");
+
+  (* a field carrying no json_name is unaffected *)
+  check "decode still accepts camelCase"
+    ((decode (`Assoc [ "plainField", `String "x" ])).plain_field = "x");
+  check "decode still accepts snake_case"
+    ((decode (`Assoc [ "plain_field", `String "x" ])).plain_field = "x");
+
+  (* the same rules apply to the cases of a oneof *)
+  check "oneof decode accepts json_name"
+    ((decode (`Assoc [ "customCase", `String "c" ])).choice
+   = Some (Renamed_case "c"));
+  check "oneof decode accepts the proto field name"
+    ((decode (`Assoc [ "renamed_case", `String "c" ])).choice
+   = Some (Renamed_case "c"));
+  check "oneof decode rejects the superseded camelCase name"
+    ((decode (`Assoc [ "renamedCase", `String "c" ])).choice = None);
+  check "oneof decode is unaffected without json_name"
+    ((decode (`Assoc [ "plainCase", `String "p" ])).choice
+   = Some (Plain_case "p"));
+
+  match !failures with
+  | [] -> print_endline "\njson_name option ... Ok"
+  | failed ->
+    List.iter
+      (Printf.eprintf "json_name option ... FAILED: %s\n")
+      (List.rev failed);
+    exit 1


### PR DESCRIPTION
Fixes #158.

## Summary

`ocaml-protoc` currently ignores the `json_name` field option.  A `.proto` file
can declare one, the parser accepts it, and it is then silently dropped, so the
generated JSON codec uses the camelCased field name anyway.  The JSON that comes
out is not the JSON any other protobuf implementation produces for that
descriptor.

This makes both JSON backends honor `json_name`, and closes a related gap in the
`bs` backend.

## Problem

Given this `.proto`:

```proto
message M {
  string renamed_field = 1 [json_name = "custom_JSON_name"];
}
```

`ocaml-protoc --yojson` on master generates:

```ocaml
assoc := ("renamedField", Pbrt_yojson.make_string v.renamed_field) :: !assoc;
...
| (("renamedField" | "renamed_field"), json_value) -> ...
```

`custom_JSON_name` appears nowhere.  Anything exchanging JSON with a peer that
uses the same `.proto` therefore disagrees with it on the wire, in both
directions, with no diagnostic.

Separately, 5318252 ("more compliant decoding for json") taught the **yojson**
decoder to accept the original proto field name alongside the camelCase one, as
ProtoJSON requires of parsers.  The **bs** decoder never got that fix and still
accepts the camelCase spelling only.

## Fix

`Pb_codegen_util.json_label_of_label` / `json_label_of_constructor` resolve a
field's JSON name once: the `json_name` option when the `.proto` sets one to a
string, and `camel_case_of_label` otherwise.  The four codegen files thread that
value where they previously called `camel_case_of_label` inline.  `rf_options`
and `vc_options` were already carried on the IR, so nothing new had to be
plumbed through the compiler.

Per ProtoJSON, `json_name` **replaces** the camelCase key rather than adding to
it.  So for a renamed field the encoders emit the `json_name`, and the decoders
accept exactly two spellings, the `json_name` and the original proto field name.
The camelCase name the field would otherwise have had is deliberately not
accepted.  The existing `field_name_pattern` helper already collapses to a single
pattern when the two coincide, so unrenamed fields generate byte-identical code
to before.

The `bs` decoder gets the same dual-name treatment.  Because it looks the value
up with `Js.Dict.unsafeGet json "<literal>"`, the matched key has to be bound
when the two spellings differ:

```ocaml
| (("custom_JSON_name" | "renamed_field") as key) ->
  let json = Js.Dict.unsafeGet json key in
```

The binding is only introduced when the two names differ, so the generated code
does not pick up an unused variable warning in the common case.

Enum values are untouched: they already encode via `cvc_string_value`, which is
the name as written in the `.proto`, which is what ProtoJSON specifies.

## Testing

`dune runtest` is green, including the pre-existing yojson suite and the
`Google unittest` conformance run.

New `JsonName` message in `src/tests/yojson/yojson_unittest.proto` plus a block
in `yojson_unittest_ml.ml` covering, for a plain field and for a `oneof` case:
encoding uses the `json_name`; decoding accepts the `json_name`; decoding
accepts the proto field name; decoding does **not** accept the superseded
camelCase name; and fields with no `json_name` behave exactly as before.

The expected behavior was not taken from memory.  It was measured against
`protoc` 23.2 and the protobuf 7.35.1 Python runtime: every accepted and
rejected spelling in the test mirrors a row of that oracle, including the
decisive one, that `{"renamedField": ...}` is rejected once `json_name` is set.
The oracle harness carries negative cases and reports whether they were actually
rejected, so a harness that silently accepted everything would not have been
mistaken for agreement.

The new test was confirmed by mutation, not just by passing.  Seven mutants, one
per changed decision (ignore `json_name` in each of the four codegen sites, make
the option reader always return `None`, and drop each half of the decoder's
two-name pattern) were each applied, seen to fail the suite, and restored.

## Known gap, disclosed rather than papered over

An eighth mutant, dropping the proto-name half of the **bs** decoder's pattern,
**survives** the suite.  That is not a weakness of this change specifically: the
repository has no automated coverage of the bs backend at all, since exercising
it needs a JavaScript toolchain.  The bs half of this change was verified by
reading the generated output, quoted above, rather than by a test.  Happy to add
a bs codegen fixture with an `.expected` file if you would like that coverage.

## Notes for the reviewer

- A `json_name` whose value is not a string constant is ignored and the field
  falls back to camelCase, rather than being rejected.  That matches how the rest
  of the compiler treats options it does not recognise.  `protoc` errors on it,
  so tightening this is an easy follow-up if you would prefer it.
- `protoc` also rejects a `json_name` that collides with another field's JSON
  name.  This change does not add that check, so a collision produces two
  identical match arms and an unused-match-case warning in the generated code.
  That hazard already exists on master for two fields that camelCase to the same
  key, so it is not new here, but it is easier to trigger now.  Happy to add the
  check.
- The issue also asks about *disabling* camelCasing wholesale, which upstream
  exposes as a printer option (`preserve_proto_field_names` in C++,
  `UseProtoNames` in Go).  That is a separate feature and I left it out: codegen
  plugins do not currently receive the command line settings or the file
  options, so a global flag needs a new channel into the backends, which felt
  like it deserved its own PR and your opinion on the plumbing.  `json_name` is
  the per-field, spec-defined way to get the same result and needs no new
  surface.
