### PR TITLE
parse `reserved "name";` in message and enum bodies (#252)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,20 @@
 
+## 4.2
+
+- fix parser: handle `reserved "name", ...;` (reserved field names) in message
+    and enum bodies, alongside the existing numeric form. As with reserved
+    numbers before it, the enum form parses but is not retained in the parse
+    tree
+- fix parser: a `reserved` statement in a message body is now recorded as
+    `Pt.Message_reserved`; it was being recorded as `Pt.Message_extension`
+
+breaking:
+
+- `ocaml-protoc.compiler-lib`: `Pb_parsing_util.message_body_reserved` now takes
+    the new `Pt.reserved` sum type (`Reserved_ranges` / `Reserved_names`) instead
+    of `Pt.extension_range list`, and `Pt.Message_reserved`'s payload changes
+    with it
+
 ## 4.1
 
 - bugfix for large signed int64 in pbrt

--- a/src/compilerlib/pb_parsing_parse_tree.ml
+++ b/src/compilerlib/pb_parsing_parse_tree.ml
@@ -99,6 +99,12 @@ type extension_range =
   | Extension_single_number of int
   | Extension_range of extension_range_from * extension_range_to
 
+(** A [reserved] statement reserves either field numbers/ranges or field names;
+    the two forms are mutually exclusive within a single statement. *)
+type reserved =
+  | Reserved_ranges of extension_range list
+  | Reserved_names of string list
+
 (** Body content defines all the possible consituant of a message. *)
 type message_body_content =
   | Message_field of message_field
@@ -107,7 +113,7 @@ type message_body_content =
   | Message_sub of message
   | Message_enum of enum
   | Message_extension of extension_range list
-  | Message_reserved of extension_range list
+  | Message_reserved of reserved
   | Message_option of Pb_raw_option.t
 
 and message = {
@@ -252,6 +258,21 @@ let pp_extension_range ppf ext_range =
   | Extension_range (from, to_) ->
     fprintf ppf "(Extension_range (%d, %a))" from pp_extension_range_to to_
 
+let pp_reserved ppf reserved =
+  match reserved with
+  | Reserved_ranges ranges ->
+    fprintf ppf "Reserved_ranges [@[<v>%a@]]"
+      (pp_print_list
+         ~pp_sep:(fun ppf () -> fprintf ppf ";@,")
+         pp_extension_range)
+      ranges
+  | Reserved_names names ->
+    fprintf ppf "Reserved_names [@[<v>%a@]]"
+      (pp_print_list
+         ~pp_sep:(fun ppf () -> fprintf ppf ";@,")
+         (fun ppf s -> fprintf ppf "%S" s))
+      names
+
 let rec pp_message_body_content ppf msg_body_content =
   match msg_body_content with
   | Message_field field -> pp_message_field ppf field
@@ -265,12 +286,8 @@ let rec pp_message_body_content ppf msg_body_content =
          ~pp_sep:(fun ppf () -> fprintf ppf ";@,")
          pp_extension_range)
       ext_ranges
-  | Message_reserved res_ranges ->
-    fprintf ppf "Message_reserved [@[<v>%a@]]"
-      (pp_print_list
-         ~pp_sep:(fun ppf () -> fprintf ppf ";@,")
-         pp_extension_range)
-      res_ranges
+  | Message_reserved reserved ->
+    fprintf ppf "Message_reserved %a" pp_reserved reserved
   | Message_option option -> Pb_raw_option.pp_t ppf option
 
 and pp_message ppf message =

--- a/src/compilerlib/pb_parsing_parser.mly
+++ b/src/compilerlib/pb_parsing_parser.mly
@@ -92,7 +92,7 @@
 %start extension_
 %type <Pb_parsing_parse_tree.extension_range list> extension_
 %start reserved_
-%type <Pb_parsing_parse_tree.extension_range list> reserved_
+%type <Pb_parsing_parse_tree.reserved> reserved_
 %start extend_
 %type <Pb_parsing_parse_tree.extend> extend_
 
@@ -193,8 +193,8 @@ extension :
   | T_extensions extension_range_list semicolon {$2}
 
 reserved :
-  | T_reserved extension_range_list semicolon {$2}
-/* T_toDO: incomplete, reserved field can also be defined by field names */
+  | T_reserved extension_range_list semicolon { Pb_parsing_util.reserved_of_ranges $2 }
+  | T_reserved reserved_name_list semicolon   { Pb_parsing_util.reserved_of_names $2 }
 
 service :
   | T_service T_ident T_lbrace service_body_content_list rbrace {
@@ -270,6 +270,10 @@ extension_range :
   | T_int { Pb_parsing_util.extension_range_single_number $1}
   | T_int T_to T_int { Pb_parsing_util.extension_range_range $1 (`Number $3) }
   | T_int T_to T_max { Pb_parsing_util.extension_range_range $1 `Max }
+
+reserved_name_list :
+  | T_string                            {$1 :: []}
+  | T_string T_comma reserved_name_list {$1 :: $3}
 
 oneof :
   | T_one_of field_name T_lbrace oneof_field_list rbrace {

--- a/src/compilerlib/pb_parsing_util.ml
+++ b/src/compilerlib/pb_parsing_util.ml
@@ -102,9 +102,9 @@ let message_body_enum enum = Pt.Message_enum enum
 let message_body_extension extension_ranges =
   Pt.Message_extension extension_ranges
 
-let message_body_reserved extension_ranges =
-  Pt.Message_extension extension_ranges
-
+let reserved_of_ranges extension_ranges = Pt.Reserved_ranges extension_ranges
+let reserved_of_names names = Pt.Reserved_names names
+let message_body_reserved reserved = Pt.Message_reserved reserved
 let message_body_option option_ = Pt.Message_option option_
 
 let message ~content message_name =

--- a/src/compilerlib/pb_parsing_util.mli
+++ b/src/compilerlib/pb_parsing_util.mli
@@ -74,7 +74,9 @@ val extension_range_range :
 val message_body_sub : Pt.message -> Pt.message_body_content
 val message_body_enum : Pt.enum -> Pt.message_body_content
 val message_body_extension : Pt.extension_range list -> Pt.message_body_content
-val message_body_reserved : Pt.extension_range list -> Pt.message_body_content
+val reserved_of_ranges : Pt.extension_range list -> Pt.reserved
+val reserved_of_names : string list -> Pt.reserved
+val message_body_reserved : Pt.reserved -> Pt.message_body_content
 val message_body_option : Pb_raw_option.t -> Pt.message_body_content
 val message : content:Pt.message_body_content list -> string -> Pt.message
 

--- a/src/tests/unit-tests/dune
+++ b/src/tests/unit-tests/dune
@@ -3,6 +3,7 @@
  (names graph_test format_play_ground lexer_comment ocaml_codegen_test
    parse_enum pbtt_compile_p2 test_typing verify_syntax_invariants
    parse_message parse_field_options parse_file_options parse_import
-   pbtt_compile_p1 backend_ocaml_test)
+   pbtt_compile_p1 backend_ocaml_test parse_extension_range
+   parse_reserved_names)
  (libraries pbrt ocaml-protoc.compiler-lib)
  (flags :standard -open Ocaml_protoc_compiler_lib))

--- a/src/tests/unit-tests/parse_extension_range.ml
+++ b/src/tests/unit-tests/parse_extension_range.ml
@@ -62,12 +62,12 @@ let () =
   let s = "reserved 1,2,3 to 10, 11 to max;" in
   let ev = parse_reserved s in
   (match ev with
-  | [ ev1; ev2; ev3; ev4 ] ->
+  | Pt.Reserved_ranges [ ev1; ev2; ev3; ev4 ] ->
     assert (Pt.Extension_single_number 1 = ev1);
     assert (Pt.Extension_single_number 2 = ev2);
     assert (Pt.Extension_range (3, Pt.To_number 10) = ev3);
     assert (Pt.Extension_range (11, Pt.To_max) = ev4)
-  | _ -> (assert false : unit));
+  | Pt.Reserved_ranges _ | Pt.Reserved_names _ -> (assert false : unit));
   ()
 
 let test_failure f =
@@ -84,6 +84,30 @@ let () =
 let () =
   let s = "1 to min" in
   test_failure (fun () -> parse s);
+  ()
+
+(* protoc rejects mixing reserved numbers and reserved names in a single
+   statement, in either order; so must we. *)
+let () =
+  let s = "reserved 2, \"foo\";" in
+  test_failure (fun () -> parse_reserved s);
+  ()
+
+let () =
+  let s = "reserved \"foo\", 2;" in
+  test_failure (fun () -> parse_reserved s);
+  ()
+
+(* protoc rejects a trailing comma in a reserved name list. *)
+let () =
+  let s = "reserved \"foo\", \"bar\",;" in
+  test_failure (fun () -> parse_reserved s);
+  ()
+
+(* protoc rejects an operand-less reserved statement. *)
+let () =
+  let s = "reserved;" in
+  test_failure (fun () -> parse_reserved s);
   ()
 
 let () = print_endline "Parse Extension Range... Ok"

--- a/src/tests/unit-tests/parse_reserved_names.ml
+++ b/src/tests/unit-tests/parse_reserved_names.ml
@@ -1,0 +1,251 @@
+(* Tests for `reserved "name", ...;` support (upstream issue #252).
+
+   Everything here is expressed as a boolean-valued check so that a failure is
+   reported by name rather than by an opaque exception. *)
+
+module Pt = Pb_parsing_parse_tree
+
+let parse_reserved s =
+  Pb_parsing_parser.reserved_ Pb_parsing_lexer.lexer (Lexing.from_string s)
+
+let parse_message s =
+  Pb_parsing_parser.message_ Pb_parsing_lexer.lexer (Lexing.from_string s)
+
+let parse_enum s =
+  Pb_parsing_parser.enum_ Pb_parsing_lexer.lexer (Lexing.from_string s)
+
+let parse_oneof s =
+  Pb_parsing_parser.oneof_ Pb_parsing_lexer.lexer (Lexing.from_string s)
+
+let reserved_of_body body =
+  List.filter_map
+    (function
+      | Pt.Message_reserved reserved -> Some reserved
+      | Pt.Message_field _ | Pt.Message_map_field _ | Pt.Message_oneof_field _
+      | Pt.Message_sub _ | Pt.Message_enum _ | Pt.Message_extension _
+      | Pt.Message_option _ ->
+        None)
+    body
+
+let sub_messages_of body =
+  List.filter_map
+    (function
+      | Pt.Message_sub sub -> Some sub
+      | Pt.Message_field _ | Pt.Message_map_field _ | Pt.Message_oneof_field _
+      | Pt.Message_enum _ | Pt.Message_extension _ | Pt.Message_reserved _
+      | Pt.Message_option _ ->
+        None)
+    body
+
+let sub_enums_of body =
+  List.filter_map
+    (function
+      | Pt.Message_enum sub -> Some sub
+      | Pt.Message_field _ | Pt.Message_map_field _ | Pt.Message_oneof_field _
+      | Pt.Message_sub _ | Pt.Message_extension _ | Pt.Message_reserved _
+      | Pt.Message_option _ ->
+        None)
+    body
+
+let enum_value_names_of enum =
+  List.filter_map
+    (function
+      | Pt.Enum_value { Pt.enum_value_name; _ } -> Some enum_value_name
+      | Pt.Enum_option _ -> None)
+    enum.Pt.enum_body
+
+let reserved_of_message s = reserved_of_body (parse_message s).Pt.message_body
+
+(* --- the `reserved_` entry point, name forms ------------------------------ *)
+
+let check_single_name () =
+  parse_reserved {|reserved "foo";|} = Pt.Reserved_names [ "foo" ]
+
+let check_multi_name () =
+  parse_reserved {|reserved "foo", "bar";|} = Pt.Reserved_names [ "foo"; "bar" ]
+
+(* protoc performs no identifier-shape re-validation on a reserved name, so the
+   empty string is accepted and carried through opaquely. *)
+let check_empty_name () =
+  parse_reserved {|reserved "";|} = Pt.Reserved_names [ "" ]
+
+let check_numeric_still_ranges () =
+  parse_reserved "reserved 1, 2;"
+  = Pt.Reserved_ranges
+      [ Pt.Extension_single_number 1; Pt.Extension_single_number 2 ]
+
+let check_numeric_range_still_ranges () =
+  parse_reserved "reserved 9 to 11, 20 to max;"
+  = Pt.Reserved_ranges
+      [
+        Pt.Extension_range (9, Pt.To_number 11);
+        Pt.Extension_range (20, Pt.To_max);
+      ]
+
+(* --- message-body wiring (pb_parsing_util.message_body_reserved) ---------- *)
+
+let check_message_wiring_numeric () =
+  match reserved_of_message "message M { reserved 2, 15; }" with
+  | [
+   Pt.Reserved_ranges
+     [ Pt.Extension_single_number 2; Pt.Extension_single_number 15 ];
+  ] ->
+    true
+  | [] | [ Pt.Reserved_ranges _ ] | [ Pt.Reserved_names _ ] | _ :: _ :: _ ->
+    false
+
+let check_message_wiring_names () =
+  match reserved_of_message {|message M { reserved "foo", "bar"; }|} with
+  | [ Pt.Reserved_names [ "foo"; "bar" ] ] -> true
+  | [] | [ Pt.Reserved_names _ ] | [ Pt.Reserved_ranges _ ] | _ :: _ :: _ ->
+    false
+
+let check_nested_message_names () =
+  match
+    sub_messages_of
+      (parse_message {|message M { message N { reserved "foo"; } }|})
+        .Pt.message_body
+  with
+  | [ sub ] ->
+    reserved_of_body sub.Pt.message_body = [ Pt.Reserved_names [ "foo" ] ]
+  | [] | _ :: _ :: _ -> false
+
+(* --- enum bodies ---------------------------------------------------------- *)
+
+(* The grammar deliberately discards enum-level reserved data (enum_values
+   drops $1), so the observable property is that the statement parses and the
+   surrounding enum values survive intact. *)
+let check_enum_names () =
+  match parse_enum {|enum E { reserved "FOO", "BAR"; A = 0; }|} with
+  | enum -> enum_value_names_of enum = [ "A" ]
+  | exception Parsing.Parse_error -> false
+  | exception Failure _ -> false
+
+let check_enum_numeric_still_parses () =
+  match parse_enum "enum E { reserved 2, 15; A = 0; }" with
+  | enum -> enum_value_names_of enum = [ "A" ]
+  | exception Parsing.Parse_error -> false
+  | exception Failure _ -> false
+
+let check_nested_enum_names () =
+  match
+    sub_enums_of
+      (parse_message {|message M { enum E { reserved "FOO"; A = 0; } }|})
+        .Pt.message_body
+  with
+  | [ sub ] -> enum_value_names_of sub = [ "A" ]
+  | [] | _ :: _ :: _ -> false
+
+(* --- the parse-tree printers --------------------------------------------- *)
+
+(* `Pt.pp_proto`'s only consumer in this repo is
+   src/tests/expectation/test_option_parsing.ml, and none of its fixture protos
+   contains a `reserved` statement, so `pp_reserved` and the `Message_reserved`
+   arm of `pp_message_body_content` would otherwise be pinned by nothing.  These
+   checks assert the rendered text directly.  Single-element lists are used on
+   purpose: the list separator sits inside a vertical box, so a multi-element
+   rendering depends on Format's line breaking rather than on the labels under
+   test. *)
+
+let render_reserved reserved = Format.asprintf "%a" Pt.pp_reserved reserved
+
+let render_body_content content =
+  Format.asprintf "%a" Pt.pp_message_body_content content
+
+let check_pp_names_label () =
+  render_reserved (Pt.Reserved_names [ "foo" ]) = {|Reserved_names ["foo"]|}
+
+let check_pp_ranges_label () =
+  render_reserved (Pt.Reserved_ranges [ Pt.Extension_single_number 2 ])
+  = "Reserved_ranges [(Extension_single_number 2)]"
+
+let check_pp_message_reserved_label () =
+  render_body_content (Pt.Message_reserved (Pt.Reserved_names [ "foo" ]))
+  = {|Message_reserved Reserved_names ["foo"]|}
+
+(* --- negative controls (protoc rejects all of these) ---------------------- *)
+
+let rejects parse s =
+  match parse s with
+  | true | false -> false
+  | exception Parsing.Parse_error -> true
+  | exception Failure _ -> true
+
+let reserved_parses s =
+  match parse_reserved s with
+  | Pt.Reserved_ranges _ | Pt.Reserved_names _ -> true
+
+let message_parses s =
+  match parse_message s with
+  | (_ : Pt.message) -> true
+
+let oneof_parses s =
+  match parse_oneof s with
+  | (_ : Pt.oneof) -> true
+
+let check_bare_ident_rejected () = rejects reserved_parses "reserved foo;"
+
+let check_mixed_number_first_rejected () =
+  rejects reserved_parses {|reserved 2, "foo";|}
+
+let check_mixed_name_first_rejected () =
+  rejects reserved_parses {|reserved "foo", 2;|}
+
+let check_trailing_comma_rejected () =
+  rejects reserved_parses {|reserved "foo", "bar",;|}
+
+let check_empty_statement_rejected () = rejects reserved_parses "reserved;"
+
+let check_message_mixed_rejected () =
+  rejects message_parses {|message M { reserved 2, "foo"; }|}
+
+(* protoc's oneof body has no reserved alternative at all ("Expected field
+   name."); this fix must not introduce one. *)
+let check_oneof_reserved_rejected () =
+  rejects oneof_parses {|oneof o { reserved "foo"; }|}
+
+let checks =
+  [
+    "single quoted name", check_single_name;
+    "comma-separated names", check_multi_name;
+    "empty name string accepted", check_empty_name;
+    "numeric form still Reserved_ranges", check_numeric_still_ranges;
+    "numeric range form still Reserved_ranges", check_numeric_range_still_ranges;
+    ( "message wiring: numeric -> Message_reserved(Reserved_ranges)",
+      check_message_wiring_numeric );
+    ( "message wiring: names -> Message_reserved(Reserved_names)",
+      check_message_wiring_names );
+    "nested message: names retained", check_nested_message_names;
+    "enum body: names parse", check_enum_names;
+    "enum body: numeric still parses", check_enum_numeric_still_parses;
+    "nested enum: names parse", check_nested_enum_names;
+    "pp_reserved labels the name case Reserved_names", check_pp_names_label;
+    "pp_reserved labels the range case Reserved_ranges", check_pp_ranges_label;
+    ( "pp_message_body_content labels the node Message_reserved",
+      check_pp_message_reserved_label );
+    "bare/unquoted identifier form rejected", check_bare_ident_rejected;
+    "mixed number-then-name rejected", check_mixed_number_first_rejected;
+    "mixed name-then-number rejected", check_mixed_name_first_rejected;
+    "trailing comma rejected", check_trailing_comma_rejected;
+    "empty reserved statement rejected", check_empty_statement_rejected;
+    "mixed form rejected inside a message body", check_message_mixed_rejected;
+    "reserved rejected inside a oneof body", check_oneof_reserved_rejected;
+  ]
+
+(* A check that raises (rather than returning false) is a failure too; convert
+   the parser's exceptions into the boolean at this one boundary so that every
+   failure is reported by name instead of aborting the whole binary. *)
+let run_check check =
+  match check () with
+  | true -> true
+  | false -> false
+  | exception Parsing.Parse_error -> false
+  | exception Failure _ -> false
+
+let () =
+  let failed = List.filter (fun (_, check) -> not (run_check check)) checks in
+  List.iter (fun (name, _) -> Printf.printf "FAIL: %s\n" name) failed;
+  if failed = [] then
+    print_endline "Parse Reserved Names... Ok"
+  else
+    exit 1


### PR DESCRIPTION
Fixes #252.

## Problem

`reserved` can reserve field *names*, not just field numbers, and protobuf's own
`descriptor.proto` uses that form.  `ocaml-protoc` only ever accepted the numeric form, so
the file the issue reports dies on it:

```
/usr/include/google/protobuf/descriptor.proto:497:33: Parsing error at `reserved 42 ; reserved "php_generic_services" <<< HERE'
```

The grammar had one alternative and a note saying so:

```
reserved :
  | T_reserved extension_range_list semicolon {$2}
/* T_toDO: incomplete, reserved field can also be defined by field names */
```

`extension_range` only ever starts with `T_int`, so a `T_string` operand is a hard syntax
error.  This is not a corner case of the language.  Across a corpus of 9,231 real `.proto`
files (googleapis, grpc-proto, envoyproxy's data-plane-api, protobuf's own tree, and this
repo's `descriptor_main.proto`), 101 files contain a `reserved` statement, 294 statements in
total, and 69 of those reserve names.  Every one of the 69 uses the same shape: a
comma-separated list of double-quoted strings.

| operand shape | statements in the corpus |
| --- | --- |
| numbers and ranges (`2, 15`, `9 to 11`, `9 to max`) | 213 |
| double-quoted names (`"foo"` / `"foo", "bar"`) | 69 (51 single-name, 18 multi-name) |
| bare identifiers (`reserved foo;`) | 12, all in protobuf's own edition-gated fixtures |
| numbers and names mixed in one statement | 0 |
| trailing comma before the `;` | 0 |
| single-quoted names | 0 |

## Fix

Three small changes, all in the parser layer.

* `pb_parsing_parser.mly` splits `reserved` into two alternatives that are disjoint on their
  first token, `T_int` for the existing `extension_range_list` and `T_string` for a new
  right-recursive `reserved_name_list`.  Because the two lists are separate nonterminals,
  mixing numbers and names in one statement, and a trailing comma in either list, stay
  rejected without a single line of extra checking, which is what `protoc` does.
* `Pt.Message_reserved`'s payload widens from `extension_range list` to a new two-constructor
  `Pt.reserved` (`Reserved_ranges` / `Reserved_names`).  Widening the existing constructor
  rather than adding a sibling means the compiler points at every site that has to be
  considered.
* `Pb_parsing_util` gains `reserved_of_ranges` and `reserved_of_names`, and `pp_reserved` is
  added next to the existing printers.

No lexer change, no new token, and no change to the `oneof` grammar.

### The adjacent bug this forces

`Pb_parsing_util.message_body_reserved` was building `Pt.Message_extension`, not
`Pt.Message_reserved`:

```ocaml
let message_body_reserved extension_ranges =
  Pt.Message_extension extension_ranges
```

So every `reserved 2, 15;` was recorded as an *extension range*, and `Pt.Message_reserved`
was never constructed by anything.  The type widening makes that line stop compiling, so the
fix is forced rather than optional.

I want to be precise about its impact, because it is easy to overstate.  Today this is a
latent bug with no observable consequence.  The mis-tagged ranges were being appended to
`Tt.extensions` by `pb_typing_validation.ml:255-256`; `Tt.extensions` is written there,
copied through `pb_typing_resolution.ml`, and read by no backend, so nothing generated
changed.  After the fix those ranges land in `Message_reserved` and are dropped at
`pb_typing_validation.ml:257-258` by the pre-existing `TODO` no-op instead.  The corpus
codegen comparison below confirms this empirically: byte-identical output on every real file
both binaries compile, including files with several numeric `reserved` statements.

## Testing

**`ocamlyacc` conflicts: 0 shift/reduce, 0 reduce/reduce.**  Measured on the literal applied
`.mly` (the measured copy was `diff`ed against the repo file and is identical), 307 states
against 302 on `origin/master`.  `ocamlyacc` is silent and exits 0 on a clean grammar, so the
silence was checked against a positive control: the same recipe on a deliberately ambiguous
variant of the same rule prints `2 shift/reduce conflicts.`  Both numbers were measured three
times: while writing the patch, independently afterwards, and once more from scratch against
`git show origin/master:src/compilerlib/pb_parsing_parser.mly` (master `302`, last line
`state 301`; branch `307`, last line `state 306`; zero `conflict` matches in either `.output`).

**Existing suite: unchanged.**  `dune runtest --profile=release --force` is RC=0 before and
after.  On the switch I used (OCaml 5.3.0) the master baseline is already fully green, so there is no
pre-existing failing set to compare against; the entire diff of the suite output against the
master run is two added lines, the two new test banners.  Nothing that passed before stopped
passing.

**Differential against `protoc` 23.2**, 57 hand-written cases covering both message and enum
bodies (accept forms, reject forms, proto2, nesting, editions):

| | agrees with `protoc` |
| --- | --- |
| master | 33/57 |
| this PR | 41/57 |

Fourteen rows are fixed: every name-accepting form in both bodies, single and multi-name,
proto2 and proto3, nested message and nested enum, and the odd-but-legal name strings
(`"not an ident"`, `""`, `"1abc"`) that `protoc` accepts without re-validating their shape.
The rows that matter most for safety all agree as **reject** on both sides: mixed
number-then-name and name-then-number, trailing comma in either list, bare `reserved;`, bare
unquoted identifier, and `reserved` inside a `oneof` body.

Six rows move the other way, three in message bodies (oracle rows m14/m15/m18) and the three parallel enum-body rows (e14/e15/e18), and I would rather flag them than bury them.  On master,
`reserved "foo", "foo";`, two `reserved "foo";` statements in one message, and
`reserved "foo"; string foo = 1;` were rejected, but only because the name form did not parse
at all.  `protoc` rejects them for a real semantic reason (a name reserved twice, a field
using a reserved name).  Now that names parse, `ocaml-protoc` accepts them, because
`pb_typing_validation.ml:257-258` is an explicit `(* TODO add support for checking reserved
fields *)` no-op.  That no-op predates this change and already applied to the numeric form
(duplicate and overlapping reserved *numbers* are accepted on master too, oracle rows
m16/m17/m19 and e16/e17/e19).  Adding the semantic check for names only, and not for numbers,
would have been inconsistent; adding it for both is a larger change than this issue asks for.
Happy to do it in a follow-up if you want it.

**No codegen regression on real protos.**  A pristine `origin/master` binary was built from a
`git archive` export and both binaries were run over 8,868 of the corpus files with matching
include roots (that run recursed into `protobuf/src` rather than the whole `protobuf` tree,
which is why it is 8,868 and not 9,231).  3,785 files compile under both, and the generated `.ml`
and `.mli` are byte-identical for all 3,785 (`filecmp` with `shallow=False`, plus a hand
`diff` on `grpc/channelz/v1/channelz.proto`, which has four numeric `reserved` statements and
is the sharpest test of the widened payload).  Zero files that master could compile fail now.
Eight real files compile that master could not, all of them blocked on a named `reserved`
statement: `google/maps/weather/v1/map_types.proto`, three `backstory` protos, three
`grpc/lookup` and `service_config` protos, and `test_messages_proto3.proto`.  The remaining
files fail on both binaries for unrelated, pre-existing reasons (unvendored third-party
imports, PGV bracketed field options, `descriptor.proto`'s own `extensions N [...]` syntax,
which both binaries reject with the byte-identical error).

**New unit test** `src/tests/unit-tests/parse_reserved_names.ml`: 21 named checks, of which 7
are negative and 3 cover the printers.  The positive checks assert the parsed structure, not
just that parsing succeeded, and they cover both the bare `reserved_` entry point and a full
message parse, so the grammar fix and the `message_body_reserved` fix have separate signals.
The negative checks pin the disjointness rules and the `oneof` boundary.  The printer checks
compare `Format.asprintf "%a"` output against an exact literal, using single-element lists so
that the assertion depends on the constructor labels rather than on Format's line breaking
inside the `@[<v>` box.

This PR also wires `src/tests/unit-tests/parse_extension_range.ml` into the `dune` stanza's
`names` list.  It was added in 3827425 (2024-01-14) but never listed there, so it has never
run.  It is adapted to the new payload type and gains four negative cases.

**Mutation battery: 25 mutants, one per changed decision, applied and reverted one at a time.**
18 were killed by a named test failing.  I am listing the other 7 rather than quoting a
kill rate:

* **3 are killed only by the compiler**, not by a test: reverting the `Message_reserved`
  payload, reverting the `%type` of `reserved_`, and deleting `val reserved_of_names` from the
  `.mli` are all type errors.  That is the intended consequence of widening the existing
  constructor, but it is a type-system guarantee and not test coverage, so it is recorded that
  way.
* **2 are equivalent mutants.**  Adding a number-then-name or name-then-number mixing
  alternative to the `reserved` rule survives, but each one makes `ocamlyacc` report
  `1 shift/reduce conflict.` and its default shift leaves the new item unreachable, so
  behaviour does not actually change.  Replacements that really do over-accept (an
  LR-compatible mixing nonterminal with no new conflicts, and `| T_int` added to
  `reserved_name_list`) were built and both are killed.
* **2 genuinely survive, and this PR does not close them.**  Both are the `dune` `names`
  wiring itself.  Removing either new test module from the stanza leaves `dune runtest` at
  RC=0 with the banner silently gone, which is exactly the failure mode that left
  `parse_extension_range.ml` dead since January 2024.  To be precise about what this PR does
  and does not do: it **revives** that file, and it does **not** make the failure mode
  self-detecting.  A future removal from `(names ...)` would again go unnoticed, because a
  `tests` stanza only gates on the exit code of each executable it is told to build, and a
  module that is not named is never built at all.  What would close it is either a
  `(rule (alias runtest) ...)` capturing the runner's stdout plus a
  `(diff banner.expected banner.actual)` golden pair, or a CI step asserting that both banner
  lines appear in the `dune runtest` output.  I have left both out rather than impose them,
  because either one deviates from the `(tests (names ...))` style this directory and its
  siblings use throughout, and inventing a new test-wiring convention inside a parser fix is a
  bigger and more opinionated change than the issue asks for.  Happy to add whichever you
  prefer if you want it in this PR.

Two mutants that had survived in an earlier round are now killed, and the tests that kill them
are new in this PR.  `pp_reserved` printing names under the `Reserved_ranges` label, and
`pp_message_body_content` printing `Message_reserved` as `Message_extension`, both used to
leave the suite green, because the only consumer of `Pt.pp_proto` is
`src/tests/expectation/test_option_parsing.ml` and none of its fixtures contains a `reserved`
statement.  Rather than add a fixture there, the three printer checks described above assert
the rendered text directly, which keeps the change inside the one new test file.  Both mutants
now fail by name, as does a third, added to mutate the *other* `pp_reserved` arm so that the
range-label check is not itself vacuous.

Apart from the three compiler-enforced ones above, no mutant was scored as killed by a build
error where a test failure was the point: one first attempt at the `oneof` mutant did not
compile and was reshaped until it did.  None was lost to a timeout.

## Deliberately not included

Each of these is measured, not assumed.  `protoc` verdicts are from the 57-case oracle above;
occurrence counts are from the 294-statement corpus.

* **Mixing numbers and names in one statement** (`reserved 2, "foo";`).  `protoc` rejects it,
  0 occurrences.  protobuf's own parser branches once on the first token and never interleaves,
  so this is a real zero rather than a corpus gap.
* **Trailing comma** (`reserved "foo", "bar",;`).  `protoc` rejects it, 0 occurrences.
* **Bare `reserved;`**.  `protoc` rejects it.
* **Unquoted identifiers** (`reserved foo;`), which is the Protobuf Editions spelling.  All 12
  corpus occurrences are inside protobuf's own edition-gated fixtures, and `protoc` 23.2
  rejects the files outright ("Expected top-level statement") because it does not support
  editions either.  `ocaml-protoc` has no awareness of the `edition` keyword anywhere, so the
  form is unreachable regardless.  A named test pins the rejection, so a future editions PR has
  to change a failing test rather than widen the grammar by accident.
* **`reserved` inside a `oneof` body**.  `protoc` rejects it ("Expected field name."), and
  `oneof_field_list` deliberately gains no `reserved` alternative.  This is the obvious
  over-acceptance trap for this change, so it has its own negative test, and the mutant that
  adds the alternative is killed by it.
* **Semantic enforcement** of reserved names and numbers against actual fields.  Discussed
  above; it is a strictly larger feature that also affects the numeric form.
* **Adjacent string concatenation** (`reserved "fo" "o";`).  `protoc` accepts this and
  `ocaml-protoc` does not, but the `string_literal` concatenation production only exists on
  b82d4a3, which is not an ancestor of this branch.  0 corpus occurrences.  Once that lands
  this is a one-token change in `reserved_name_list`.
* **Single-quoted strings** (`reserved 'foo';`).  `protoc` accepts this and `ocaml-protoc`
  does not, but that is not a `reserved` problem: the lexer only opens a string on `"`, so
  `syntax = 'proto3';` fails identically on master with `Failure("Unknown character found '")`
  and no `reserved` statement in sight.  `pb_parsing_lexer.mll` is untouched by this diff.  I
  left it alone rather than pin the current divergence with a test.

## Notes for the reviewer

* **On the issue's own file.**  The parse error the issue quotes is fixed: a
  `reserved "php_generic_services";` line no longer stops the parse.  Whether a given copy of
  `descriptor.proto` then compiles end to end depends on its version, and I would rather say so
  than imply more than I measured.  The one shipped with protobuf 23.2 in
  `/opt/homebrew/include` compiles under both master and this branch (that copy has no named
  `reserved` statement at all).  The copy in protobuf's current tree still fails, but earlier
  and for an unrelated reason, on `extensions 536000000 [declaration = {...}]` at line 37,
  where master and this branch produce the byte-identical error.  That bracketed-extension
  syntax is a separate gap.
* **Public signature change.**  `Pb_parsing_util.message_body_reserved` goes from
  `Pt.extension_range list -> Pt.message_body_content` to
  `Pt.reserved -> Pt.message_body_content`, and `Pt.Message_reserved`'s payload type changes
  with it.  Both are on the published `ocaml-protoc.compiler-lib` library, so a direct consumer
  of it will need a one-line change.  Nothing inside this repo other than the parser touches
  either.
* **Reserved names are accepted in enum bodies, but not retained.**  `reserved "GREEN", "BLUE";`
  inside an `enum` now parses, matching `protoc`, but it leaves no trace in the parse tree:
  `enum_values : | reserved enum_values { $2 }` drops the value, and `Pt.enum_body_content` has
  only `Enum_value` and `Enum_option`, so there is no constructor that could hold it.  The
  message side, by contrast, keeps a `Message_reserved` node.

  This asymmetry is not introduced here.  That production and that type are byte-identical on
  `origin/master` (`git show origin/master:src/compilerlib/pb_parsing_parser.mly` line 391, and
  `pb_parsing_parse_tree.ml` lines 82 to 84), so reserved *numbers* in an enum were already
  parsed and discarded before this change.  Reserved names now behave exactly like reserved
  numbers do, which is why I matched the existing behaviour rather than adding an
  `Enum_reserved` constructor: that would be new parse-tree surface for data nothing consumes,
  on the enum side or the message side.  Flagging it rather than adding the constructor
  uninvited.
* **`CHANGES.md` entry, and the version heading is a guess.**  I added one, covering both the
  feature and the signature change, in the file's existing style: a `- ` bullet list plus a
  `breaking:` sub-list, following the `## 3.1` section's precedent.  The file has no
  `Unreleased` convention and never has (`git show 12cf714 -- CHANGES.md` shows each section
  written whole at release-prep time), so I put it under a new `## 4.2` heading since `4.1` is
  released and tagged.  If you would rather it sit under a different version, that is a
  one-line move.
